### PR TITLE
TGP-368 Create goods description page

### DIFF
--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -33,8 +33,19 @@ class Navigator @Inject() () {
     case NirmsNumberPage  => _ => routes.HasNiphlController.onPageLoad(NormalMode)
     case HasNiphlPage     => navigateFromHasNiphl
     case NiphlNumberPage  => _ => routes.CheckYourAnswersController.onPageLoad
+    case HasGoodsDescriptionPage => navigateFromHasGoodsDescription
+    case GoodsDescriptionPage => _ => routes.CountryOfOriginController.onPageLoad(NormalMode)
     case _                => _ => routes.IndexController.onPageLoad
   }
+
+  private def navigateFromHasGoodsDescription(answers: UserAnswers): Call =
+    answers
+      .get(HasGoodsDescriptionPage)
+      .map {
+        case true => routes.GoodsDescriptionController.onPageLoad(NormalMode)
+        case false => routes.CountryOfOriginController.onPageLoad(NormalMode)
+      }
+      .getOrElse(routes.JourneyRecoveryController.onPageLoad())
 
   private def navigateFromHasNirms(answers: UserAnswers): Call =
     answers

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -27,22 +27,22 @@ import models._
 class Navigator @Inject() () {
 
   private val normalRoutes: Page => UserAnswers => Call = {
-    case ProfileSetupPage => _ => routes.UkimsNumberController.onPageLoad(NormalMode)
-    case UkimsNumberPage  => _ => routes.HasNirmsController.onPageLoad(NormalMode)
-    case HasNirmsPage     => navigateFromHasNirms
-    case NirmsNumberPage  => _ => routes.HasNiphlController.onPageLoad(NormalMode)
-    case HasNiphlPage     => navigateFromHasNiphl
-    case NiphlNumberPage  => _ => routes.CheckYourAnswersController.onPageLoad
+    case ProfileSetupPage        => _ => routes.UkimsNumberController.onPageLoad(NormalMode)
+    case UkimsNumberPage         => _ => routes.HasNirmsController.onPageLoad(NormalMode)
+    case HasNirmsPage            => navigateFromHasNirms
+    case NirmsNumberPage         => _ => routes.HasNiphlController.onPageLoad(NormalMode)
+    case HasNiphlPage            => navigateFromHasNiphl
+    case NiphlNumberPage         => _ => routes.CheckYourAnswersController.onPageLoad
     case HasGoodsDescriptionPage => navigateFromHasGoodsDescription
-    case GoodsDescriptionPage => _ => routes.CountryOfOriginController.onPageLoad(NormalMode)
-    case _                => _ => routes.IndexController.onPageLoad
+    case GoodsDescriptionPage    => _ => routes.CountryOfOriginController.onPageLoad(NormalMode)
+    case _                       => _ => routes.IndexController.onPageLoad
   }
 
   private def navigateFromHasGoodsDescription(answers: UserAnswers): Call =
     answers
       .get(HasGoodsDescriptionPage)
       .map {
-        case true => routes.GoodsDescriptionController.onPageLoad(NormalMode)
+        case true  => routes.GoodsDescriptionController.onPageLoad(NormalMode)
         case false => routes.CountryOfOriginController.onPageLoad(NormalMode)
       }
       .getOrElse(routes.JourneyRecoveryController.onPageLoad())

--- a/app/viewmodels/govuk/CharacterCountFluency.scala
+++ b/app/viewmodels/govuk/CharacterCountFluency.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.govuk
+
+import play.api.data.Field
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.hint.Hint
+import uk.gov.hmrc.govukfrontend.views.viewmodels.label.Label
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.charactercount.CharacterCount
+
+import viewmodels.ErrorMessageAwareness
+
+object characterCount extends CharacterCountFluency
+
+trait CharacterCountFluency {
+
+  object CharacterCountViewModel extends ErrorMessageAwareness {
+
+    def apply(
+               field: Field,
+               label: Label
+             )(implicit messages: Messages): CharacterCount =
+      CharacterCount(
+        id = field.id,
+        name = field.name,
+        value = field.value,
+        label = label,
+        errorMessage = errorMessage(field)
+      )
+  }
+
+  implicit class FluentCharacterCount(characterCount: CharacterCount) {
+
+    def withMaxLength(maxLength: Int): CharacterCount =
+      characterCount.copy(maxLength = Some(maxLength))
+
+    def withId(id: String): CharacterCount =
+      characterCount.copy(id = id)
+
+    def withHint(hint: Hint): CharacterCount =
+      characterCount.copy(hint = Some(hint))
+
+    def withCssClass(newClass: String): CharacterCount =
+      characterCount.copy(classes = s"${characterCount.classes} $newClass")
+
+    def withAttribute(attribute: (String, String)): CharacterCount =
+      characterCount.copy(attributes = characterCount.attributes + attribute)
+
+    def withSpellcheck(on: Boolean = true): CharacterCount =
+      characterCount.copy(spellcheck = Some(on))
+
+    def withSize(size: String): CharacterCount =
+      characterCount.withCssClass(size)
+
+    def withRows(rows: Int): CharacterCount =
+      characterCount.copy(rows = rows)
+
+    def withThreshold(threshold: Int): CharacterCount =
+      characterCount.copy(threshold = Some(threshold))
+  }
+}

--- a/app/viewmodels/govuk/CharacterCountFluency.scala
+++ b/app/viewmodels/govuk/CharacterCountFluency.scala
@@ -31,9 +31,9 @@ trait CharacterCountFluency {
   object CharacterCountViewModel extends ErrorMessageAwareness {
 
     def apply(
-               field: Field,
-               label: Label
-             )(implicit messages: Messages): CharacterCount =
+      field: Field,
+      label: Label
+    )(implicit messages: Messages): CharacterCount =
       CharacterCount(
         id = field.id,
         name = field.name,

--- a/app/viewmodels/govuk/LabelFluency.scala
+++ b/app/viewmodels/govuk/LabelFluency.scala
@@ -37,7 +37,7 @@ trait LabelFluency {
         .copy(isPageHeading = true)
         .withCssClass(size.toString)
 
-    def asSecondaryHeading(size: LabelSize = LabelSize.Large): Label =
+    def asSecondaryHeading(size: LabelSize = LabelSize.Medium): Label =
       label
         .copy(isPageHeading = false)
         .withCssClass(size.toString)

--- a/app/viewmodels/govuk/LabelFluency.scala
+++ b/app/viewmodels/govuk/LabelFluency.scala
@@ -37,6 +37,11 @@ trait LabelFluency {
         .copy(isPageHeading = true)
         .withCssClass(size.toString)
 
+    def asSecondaryHeading(size: LabelSize = LabelSize.Large): Label =
+      label
+        .copy(isPageHeading = false)
+        .withCssClass(size.toString)
+
     def withCssClass(className: String): Label =
       label.copy(classes = s"${label.classes} $className")
 

--- a/app/views/GoodsDescriptionView.scala.html
+++ b/app/views/GoodsDescriptionView.scala.html
@@ -37,6 +37,10 @@
 
     @formHelper(action = routes.GoodsDescriptionController.onSubmit(mode)) {
 
+        <h1 class="govuk-heading-xl">@messages("goodsDescription.h1")</h1>
+        <p class="govuk-body">@messages("goodsDescription.p1")</p>
+        <p class="govuk-body">@messages("goodsDescription.p2")</p>
+
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
@@ -44,11 +48,11 @@
         @textArea(
             CharacterCountViewModel(
                 field = form("value"),
-                label = LabelViewModel(messages("goodsDescription.heading")).asPageHeading()
+                label = LabelViewModel(messages("goodsDescription.inputHeading")).asSecondaryHeading()
             )
             .withRows(10)
             .withMaxLength(512)
-            .withHint(Hint(content = HtmlContent("this is a hint")))
+            .withHint(Hint(content = HtmlContent(messages("goodsDescription.hint"))))
             .withId("value")
             .withThreshold(75)
         )

--- a/app/views/GoodsDescriptionView.scala.html
+++ b/app/views/GoodsDescriptionView.scala.html
@@ -15,12 +15,19 @@
  *@
 
 @import viewmodels.InputWidth._
+@import viewmodels._
+@import viewmodels.govuk.characterCount._
+@import play.api.data.Field
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.hint.Hint
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.label.Label
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.charactercount.CharacterCount
 
 @this(
     layout: templates.Layout,
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
+    textArea: HmrcCharacterCount,
     govukButton: GovukButton
 )
 
@@ -34,12 +41,16 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @govukInput(
-            InputViewModel(
+        @textArea(
+            CharacterCountViewModel(
                 field = form("value"),
                 label = LabelViewModel(messages("goodsDescription.heading")).asPageHeading()
             )
-            .withWidth(Full)
+            .withRows(10)
+            .withMaxLength(512)
+            .withHint(Hint(content = HtmlContent("this is a hint")))
+            .withId("value")
+            .withThreshold(75)
         )
 
         @govukButton(

--- a/app/views/GoodsDescriptionView.scala.html
+++ b/app/views/GoodsDescriptionView.scala.html
@@ -15,12 +15,7 @@
  *@
 
 @import viewmodels.InputWidth._
-@import viewmodels._
 @import viewmodels.govuk.characterCount._
-@import play.api.data.Field
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.hint.Hint
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.label.Label
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.charactercount.CharacterCount
 
 @this(
     layout: templates.Layout,

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -180,9 +180,10 @@ createRecordSuccess.title = createRecordSuccess
 createRecordSuccess.heading = createRecordSuccess
 
 goodsDescription.title = Goods description
-goodsDescription.heading = Goods description
+goodsDescription.h1 = Goods description
 goodsDescription.p1 = A goods description is your description of the goods. This does not need to be unique to your Trader Goods Profile or any existing goods records.
 goodsDescription.p2 = The goods description also does not have to match tariff information.
+goodsDescription.inputHeading = What is the goods description?
 goodsDescription.hint = This can be up to 512 characters long.
 goodsDescription.checkYourAnswersLabel = Goods description
 goodsDescription.error.required = Enter the goods description

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -179,12 +179,15 @@ createRecordStart.heading = createRecordStart
 createRecordSuccess.title = createRecordSuccess
 createRecordSuccess.heading = createRecordSuccess
 
-goodsDescription.title = goodsDescription
-goodsDescription.heading = goodsDescription
-goodsDescription.checkYourAnswersLabel = goodsDescription
-goodsDescription.error.required = Enter goodsDescription
-goodsDescription.error.length = GoodsDescription must be 512 characters or less
-goodsDescription.change.hidden = GoodsDescription
+goodsDescription.title = Goods description
+goodsDescription.heading = Goods description
+goodsDescription.p1 = A goods description is your description of the goods. This does not need to be unique to your Trader Goods Profile or any existing goods records.
+goodsDescription.p2 = The goods description also does not have to match tariff information.
+goodsDescription.hint = This can be up to 512 characters long.
+goodsDescription.checkYourAnswersLabel = Goods description
+goodsDescription.error.required = Enter the goods description
+goodsDescription.error.length = The goods description must be 512 characters or less
+goodsDescription.change.hidden = Goods description
 
 hasCorrectGoods.title = hasCorrectGoods
 hasCorrectGoods.heading = hasCorrectGoods

--- a/test/controllers/GoodsDescriptionControllerSpec.scala
+++ b/test/controllers/GoodsDescriptionControllerSpec.scala
@@ -93,7 +93,7 @@ class GoodsDescriptionControllerSpec extends SpecBase with MockitoSugar {
           )
           .build()
 
-      val length = 512;
+      val length              = 512;
       val description: String = Gen.listOfN(length, Gen.alphaNumChar).map(_.mkString).sample.value
 
       running(application) {
@@ -132,7 +132,7 @@ class GoodsDescriptionControllerSpec extends SpecBase with MockitoSugar {
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
-      val invalidLength = 513;
+      val invalidLength              = 513;
       val invalidDescription: String = Gen.listOfN(invalidLength, Gen.alphaNumChar).map(_.mkString).sample.value
 
       running(application) {

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -97,6 +97,46 @@ class NavigatorSpec extends SpecBase {
           UserAnswers("id")
         ) mustBe routes.CheckYourAnswersController.onPageLoad
       }
+
+      "must go from HasGoodsDescriptionPage" - {
+
+        "to GoodsDescriptionPage when answer is Yes" in {
+
+          val answers = UserAnswers("id").set(HasGoodsDescriptionPage, true).success.value
+          navigator.nextPage(HasGoodsDescriptionPage, NormalMode, answers) mustBe routes.GoodsDescriptionController
+            .onPageLoad(
+              NormalMode
+            )
+        }
+
+        "to CountryOfOriginPage when answer is No" in {
+
+          val answers = UserAnswers("id").set(HasGoodsDescriptionPage, false).success.value
+          navigator.nextPage(HasGoodsDescriptionPage, NormalMode, answers) mustBe routes.CountryOfOriginController
+            .onPageLoad(NormalMode)
+        }
+
+        "to JourneyRecoveryPage when answer is not present" in {
+
+          val answers = UserAnswers("id")
+          navigator.nextPage(HasGoodsDescriptionPage, NormalMode, answers) mustBe routes.JourneyRecoveryController
+            .onPageLoad()
+        }
+      }
+
+      "must go from GoodsDescriptionPage" - {
+
+        "to CountryOfOriginPage" in {
+          navigator.nextPage(
+            GoodsDescriptionPage,
+            NormalMode,
+            UserAnswers("id")
+          ) mustBe routes.CountryOfOriginController.onPageLoad(
+            NormalMode
+          )
+        }
+
+      }
     }
 
     "in Check mode" - {


### PR DESCRIPTION
Scaffold offers no TextArea input, so I used HmrcCharacterCount, which supports form errors and character count warnings. I think this is standard.

Also, do we have a standard way of doing page titles (the title that appears in the tab title)

![image](https://github.com/hmrc/trader-goods-profiles-frontend/assets/34974028/751aaf3b-2ad2-440a-aeeb-a98efc7a343b)
