### PR TITLE
TGP-947 update size of input fields on pages

### DIFF
--- a/app/views/CommodityCodeView.scala.html
+++ b/app/views/CommodityCodeView.scala.html
@@ -15,6 +15,7 @@
  *@
 
 @import viewmodels.LabelSize._
+@import viewmodels.InputWidth._
 @import models.Mode
 
 @this(
@@ -47,7 +48,9 @@
             InputViewModel(
                 field = form("value"),
                 label = LabelViewModel(messages("commodityCode.heading")).withSize(Medium)
-            ).withHint(Hint(content = Text(messages("commodityCode.hint"))))
+            )
+            .withHint(Hint(content = Text(messages("commodityCode.hint"))))
+            .withWidth(Fixed10)
         )
 
         @govukButton(

--- a/app/views/UkimsNumberView.scala.html
+++ b/app/views/UkimsNumberView.scala.html
@@ -44,7 +44,9 @@
             InputViewModel(
                 field = form("value"),
                 label = LabelViewModel(messages("ukimsNumber.heading")).withSize(Medium)
-            ).withHint(Hint(content = Text(messages("ukimsNumber.hint"))))
+            )
+            .withHint(Hint(content = Text(messages("ukimsNumber.hint"))))
+            .withWidth(InputWidth.Fixed30)
         )
 
         @govukButton(

--- a/app/views/UkimsNumberView.scala.html
+++ b/app/views/UkimsNumberView.scala.html
@@ -15,6 +15,7 @@
  *@
 
 @import viewmodels.LabelSize._
+@import viewmodels.InputWidth._
 @import models.Mode
 
 
@@ -46,7 +47,7 @@
                 label = LabelViewModel(messages("ukimsNumber.heading")).withSize(Medium)
             )
             .withHint(Hint(content = Text(messages("ukimsNumber.hint"))))
-            .withWidth(InputWidth.Fixed30)
+            .withWidth(Fixed30)
         )
 
         @govukButton(


### PR DESCRIPTION
All inputs have been set to the closest that the design system allows

UKIMS has been set to width 30
Commodity Code has been set to width 10
NIRMS and NIPHLS are already set to width 10.

Please not that the input fields sizings the design system suggest give extra space anyway, do not be concerned by this.