### PR TITLE
TGP-927: Content for goods description question page

### DIFF
--- a/app/views/HasGoodsDescriptionView.scala.html
+++ b/app/views/HasGoodsDescriptionView.scala.html
@@ -14,6 +14,8 @@
  * limitations under the License.
  *@
 
+@import viewmodels.LegendSize._
+
 @this(
     layout: templates.Layout,
     formHelper: FormWithCSRF,
@@ -22,9 +24,18 @@
     govukButton: GovukButton
 )
 
+
 @(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = title(form, messages("hasGoodsDescription.title"))) {
+
+    <h1 class="govuk-heading-l">@messages("hasGoodsDescription.h1")</h1>
+    <p class="govuk-body">@messages("hasGoodsDescription.p1")</p>
+    <p class="govuk-body">@messages("hasGoodsDescription.p2")</p>
+
+    <h2 class="govuk-heading-m">@messages("hasGoodsDescription.h2")</h2>
+
+    <p class="govuk-body">@messages("hasGoodsDescription.p3")</p>
 
     @formHelper(action = routes.HasGoodsDescriptionController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
@@ -35,7 +46,7 @@
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel(messages("hasGoodsDescription.heading")).asPageHeading()
+                legend = Legend(messages("hasGoodsDescription.h3")).asPageHeading(Medium)
             )
         )
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -85,7 +85,7 @@ POST       /hasCorrectGoods                        controllers.HasCorrectGoodsCo
 GET        /changeHasCorrectGoods                  controllers.HasCorrectGoodsController.onPageLoad(mode: Mode = CheckMode)
 POST       /changeHasCorrectGoods                  controllers.HasCorrectGoodsController.onSubmit(mode: Mode = CheckMode)
 
-GET        /hasGoodsDescription                        controllers.HasGoodsDescriptionController.onPageLoad(mode: Mode = NormalMode)
-POST       /hasGoodsDescription                        controllers.HasGoodsDescriptionController.onSubmit(mode: Mode = NormalMode)
-GET        /changeHasGoodsDescription                  controllers.HasGoodsDescriptionController.onPageLoad(mode: Mode = CheckMode)
-POST       /changeHasGoodsDescription                  controllers.HasGoodsDescriptionController.onSubmit(mode: Mode = CheckMode)
+GET        /create-record/goods-description-question                   controllers.HasGoodsDescriptionController.onPageLoad(mode: Mode = NormalMode)
+POST       /create-record/goods-description-question                   controllers.HasGoodsDescriptionController.onSubmit(mode: Mode = NormalMode)
+GET        /create-record/goods-description-question/check             controllers.HasGoodsDescriptionController.onPageLoad(mode: Mode = CheckMode)
+POST       /create-record/goods-description-question/check             controllers.HasGoodsDescriptionController.onSubmit(mode: Mode = CheckMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -216,8 +216,12 @@ hasCorrectGoods.checkYourAnswersLabel = hasCorrectGoods
 hasCorrectGoods.error.required = Select yes if hasCorrectGoods
 hasCorrectGoods.change.hidden = HasCorrectGoods
 
-hasGoodsDescription.title = hasGoodsDescription
-hasGoodsDescription.heading = hasGoodsDescription
-hasGoodsDescription.checkYourAnswersLabel = hasGoodsDescription
-hasGoodsDescription.error.required = Select yes if hasGoodsDescription
-hasGoodsDescription.change.hidden = HasGoodsDescription
+hasGoodsDescription.title = Goods description
+hasGoodsDescription.h1 = Goods description
+hasGoodsDescription.p1 = A goods description is a name you can give your records to help you identify and share them.
+hasGoodsDescription.p2 = The goods description does not need to be unique to your TGP.
+hasGoodsDescription.h2 = If you do not add a goods description
+hasGoodsDescription.p3 = We will create a goods description for you. This will be the country of origin, followed by the commodity code and then the trader reference.
+hasGoodsDescription.h3 = Do you want to add a personalised goods description?
+hasGoodsDescription.checkYourAnswersLabel = hasCorrectGoods
+hasGoodsDescription.error.required = confirm if you want to add a personalised goods description


### PR DESCRIPTION
Note: The heading in the prototype is in 'xl' but it's been updated to 'l' to be consistent with other pages, I guess the design team will be confirming this, will modify accordingly if needed :)

Design : https://confluence.tools.tax.service.gov.uk/display/TGP/Goods+description+question
Prototype : https://trader-goods-profile-prototype-18527416d281.herokuapp.com/version-4/create-record/goods-description-question