### PR TITLE
TGP 1073 Get Category Assessments

### DIFF
--- a/app/connectors/OttConnector.scala
+++ b/app/connectors/OttConnector.scala
@@ -54,6 +54,8 @@ class OttConnector @Inject() (config: Configuration, httpClient: HttpClientV2)(i
               .validate[T]
               .map(result => Future.successful(result))
               .recoverTotal(error => Future.failed(JsResult.Exception(error)))
+          case _  =>
+            Future.failed(UpstreamErrorResponse(response.body, response.status))
         }
       }
       .recoverWith { case _: NotFoundException =>

--- a/app/connectors/OttConnector.scala
+++ b/app/connectors/OttConnector.scala
@@ -54,8 +54,6 @@ class OttConnector @Inject() (config: Configuration, httpClient: HttpClientV2)(i
               .validate[T]
               .map(result => Future.successful(result))
               .recoverTotal(error => Future.failed(JsResult.Exception(error)))
-          case _  =>
-            Future.failed(UpstreamErrorResponse(response.body, response.status))
         }
       }
       .recoverWith { case _: NotFoundException =>

--- a/app/connectors/OttConnector.scala
+++ b/app/connectors/OttConnector.scala
@@ -23,7 +23,7 @@ import play.api.Configuration
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, NOT_FOUND, OK}
 import play.api.libs.json.{JsResult, Reads}
 import uk.gov.hmrc.http.client.HttpClientV2
-import uk.gov.hmrc.http.{Authorization, HeaderCarrier, HttpResponse, InternalServerException, NotFoundException, StringContextOps, Upstream5xxResponse, UpstreamErrorResponse}
+import uk.gov.hmrc.http.{Authorization, HeaderCarrier, HttpResponse, NotFoundException, StringContextOps, Upstream5xxResponse, UpstreamErrorResponse}
 
 import java.net.URL
 import javax.inject.Inject

--- a/app/connectors/OttConnector.scala
+++ b/app/connectors/OttConnector.scala
@@ -31,14 +31,17 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class OttConnector @Inject() (config: Configuration, httpClient: HttpClientV2)(implicit ec: ExecutionContext) {
 
-  private val baseUrl: Service              = config.get[Service]("microservice.services.online-trade-tariff-api")
+  private val baseUrl: Service                         = config.get[Service]("microservice.services.online-trade-tariff-api")
   private def ottCommoditiesUrl(commodityCode: String) =
     url"$baseUrl/ott/commodities/$commodityCode"
 
   private def ottGreenLanesUrl(commodityCode: String) =
     url"$baseUrl/ott/goods-nomenclatures/$commodityCode"
 
-  private def getFromOtt[T](commodityCode: String, urlFunc: String => URL, authToken: String)(implicit hc: HeaderCarrier, reads: Reads[T]): Future[T] = {
+  private def getFromOtt[T](commodityCode: String, urlFunc: String => URL, authToken: String)(implicit
+    hc: HeaderCarrier,
+    reads: Reads[T]
+  ): Future[T] = {
     val newHeaderCarrier = hc.copy(authorization = Some(Authorization(authToken)))
 
     httpClient
@@ -51,7 +54,7 @@ class OttConnector @Inject() (config: Configuration, httpClient: HttpClientV2)(i
               .validate[T]
               .map(result => Future.successful(result))
               .recoverTotal(error => Future.failed(JsResult.Exception(error)))
-          case _ =>
+          case _  =>
             Future.failed(UpstreamErrorResponse(response.body, response.status))
         }
       }
@@ -60,12 +63,10 @@ class OttConnector @Inject() (config: Configuration, httpClient: HttpClientV2)(i
       }
   }
 
-  def getCommodityCode(commodityCode: String)(implicit hc: HeaderCarrier): Future[Commodity] = {
+  def getCommodityCode(commodityCode: String)(implicit hc: HeaderCarrier): Future[Commodity] =
     getFromOtt[Commodity](commodityCode, ottCommoditiesUrl, "bearerToken")
-  }
 
-  def getCategorisationInfo(commodityCode: String)(implicit hc: HeaderCarrier): Future[OttResponse] = {
+  def getCategorisationInfo(commodityCode: String)(implicit hc: HeaderCarrier): Future[OttResponse] =
     getFromOtt[OttResponse](commodityCode, ottGreenLanesUrl, "bearerToken")
-  }
 
 }

--- a/app/controllers/CategoryGuidanceController.scala
+++ b/app/controllers/CategoryGuidanceController.scala
@@ -24,7 +24,7 @@ import pages.CommodityCodePage
 import javax.inject.Inject
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import queries.CategorisationQuery
+import queries.{CategorisationQuery, CommodityQuery}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.CategoryGuidanceView
@@ -46,7 +46,7 @@ class CategoryGuidanceController @Inject() (
     with I18nSupport {
 
   def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData).async { implicit request =>
-    request.userAnswers.get(CommodityCodePage) match {
+    request.userAnswers.get(CommodityQuery) match {
       case Some(commodity) =>
         val ottResponseFuture = ottConnector.getCategorisationInfo(commodity.commodityCode)
 

--- a/app/controllers/CategoryGuidanceController.scala
+++ b/app/controllers/CategoryGuidanceController.scala
@@ -19,7 +19,6 @@ package controllers
 import connectors.OttConnector
 import controllers.actions._
 import models.ott.CategorisationInfo
-import models.ott.response.OttResponse
 import pages.CommodityCodePage
 
 import javax.inject.Inject
@@ -42,7 +41,8 @@ class CategoryGuidanceController @Inject() (
   view: CategoryGuidanceView,
   ottConnector: OttConnector,
   sessionRepository: SessionRepository
-)(implicit ec: ExecutionContext) extends FrontendBaseController
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
     with I18nSupport {
 
   def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData).async { implicit request =>
@@ -51,10 +51,10 @@ class CategoryGuidanceController @Inject() (
         val ottResponseFuture = ottConnector.getCategorisationInfo(commodity.commodityCode)
 
         for {
-          goodsNomenclature <- ottResponseFuture
+          goodsNomenclature  <- ottResponseFuture
           categorisationInfo <- Future.fromTry(Try(CategorisationInfo.build(goodsNomenclature).get))
-          updatedAnswers <- Future.fromTry(request.userAnswers.set(CategorisationQuery, categorisationInfo))
-          _ <- sessionRepository.set(updatedAnswers)
+          updatedAnswers     <- Future.fromTry(request.userAnswers.set(CategorisationQuery, categorisationInfo))
+          _                  <- sessionRepository.set(updatedAnswers)
         } yield Ok(view())
 
       case None =>

--- a/app/controllers/CategoryGuidanceController.scala
+++ b/app/controllers/CategoryGuidanceController.scala
@@ -34,6 +34,8 @@ class CategoryGuidanceController @Inject() (
     with I18nSupport {
 
   def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
+    // call ott
+    // save it?
     Ok(view())
   }
 

--- a/it/test/connectors/OttConnectorSpec.scala
+++ b/it/test/connectors/OttConnectorSpec.scala
@@ -23,7 +23,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
-import uk.gov.hmrc.http.{HeaderCarrier, Upstream4xxResponse}
+import uk.gov.hmrc.http.{HeaderCarrier, Upstream4xxResponse, Upstream5xxResponse}
 import uk.gov.hmrc.http.UpstreamErrorResponse.Upstream4xxResponse
 import uk.gov.hmrc.http.test.WireMockSupport
 
@@ -81,6 +81,17 @@ class OttConnectorSpec
 
       val connectorFailure = connector.getCommodityCode("123456").failed.futureValue
       connectorFailure.isInstanceOf[Upstream4xxResponse] mustBe true
+    }
+
+    "must return a server error future when ott returns a 5xx status" in {
+
+      wireMockServer.stubFor(
+        get(urlEqualTo(s"/ott/commodities/123456"))
+          .willReturn(serverError())
+      )
+
+      val connectorFailure = connector.getCommodityCode("123456").failed.futureValue
+      connectorFailure.isInstanceOf[Upstream5xxResponse] mustBe true
     }
   }
 
@@ -192,6 +203,17 @@ class OttConnectorSpec
 
       val connectorFailure = connector.getCategorisationInfo("123456").failed.futureValue
       connectorFailure.isInstanceOf[Upstream4xxResponse] mustEqual true
+    }
+
+    "must return a server error future when ott returns a 5xx status" in {
+
+      wireMockServer.stubFor(
+        get(urlEqualTo(s"/ott/goods-nomenclatures/123456"))
+          .willReturn(serverError())
+      )
+
+      val connectorFailure = connector.getCategorisationInfo("123456").failed.futureValue
+      connectorFailure.isInstanceOf[Upstream5xxResponse] mustBe true
     }
   }
 }

--- a/it/test/connectors/OttConnectorSpec.scala
+++ b/it/test/connectors/OttConnectorSpec.scala
@@ -27,7 +27,6 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.UpstreamErrorResponse.Upstream4xxResponse
 import uk.gov.hmrc.http.test.WireMockSupport
 
-import scala.io.Source
 
 class OttConnectorSpec
     extends AnyFreeSpec

--- a/it/test/connectors/OttConnectorSpec.scala
+++ b/it/test/connectors/OttConnectorSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.matchers.must.Matchers
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.UpstreamErrorResponse.Upstream4xxResponse
 import uk.gov.hmrc.http.test.WireMockSupport
 
 import scala.io.Source
@@ -79,7 +80,7 @@ class OttConnectorSpec
           .willReturn(notFound())
       )
 
-      connector.getCommodityCode("123456").failed.futureValue
+      connector.getCommodityCode("123456").failed.futureValue mustEqual Upstream4xxResponse
     }
   }
 
@@ -189,7 +190,7 @@ class OttConnectorSpec
           .willReturn(notFound())
       )
 
-      connector.getCategorisationInfo("123456").failed.futureValue
+      connector.getCategorisationInfo("123456").failed.futureValue mustEqual Upstream4xxResponse
     }
   }
 }

--- a/it/test/connectors/OttConnectorSpec.scala
+++ b/it/test/connectors/OttConnectorSpec.scala
@@ -23,7 +23,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
-import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.{HeaderCarrier, Upstream4xxResponse}
 import uk.gov.hmrc.http.UpstreamErrorResponse.Upstream4xxResponse
 import uk.gov.hmrc.http.test.WireMockSupport
 
@@ -79,7 +79,8 @@ class OttConnectorSpec
           .willReturn(notFound())
       )
 
-      connector.getCommodityCode("123456").failed.futureValue mustEqual Upstream4xxResponse
+      val connectorFailure = connector.getCommodityCode("123456").failed.futureValue
+      connectorFailure.isInstanceOf[Upstream4xxResponse] mustBe true
     }
   }
 
@@ -189,7 +190,8 @@ class OttConnectorSpec
           .willReturn(notFound())
       )
 
-      connector.getCategorisationInfo("123456").failed.futureValue mustEqual Upstream4xxResponse
+      val connectorFailure = connector.getCategorisationInfo("123456").failed.futureValue
+      connectorFailure.isInstanceOf[Upstream4xxResponse] mustEqual true
     }
   }
 }

--- a/test/controllers/CategoryGuidanceControllerSpec.scala
+++ b/test/controllers/CategoryGuidanceControllerSpec.scala
@@ -23,10 +23,10 @@ import models.ott.response.{GoodsNomenclatureResponse, OttResponse}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatestplus.mockito.MockitoSugar.mock
-import pages.CommodityCodePage
 import play.api.inject._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import queries.CommodityQuery
 import repositories.SessionRepository
 import views.html.CategoryGuidanceView
 
@@ -38,7 +38,7 @@ class CategoryGuidanceControllerSpec extends SpecBase {
 
     val userAnswersWithCommodity = emptyUserAnswers
       .set(
-        CommodityCodePage,
+        CommodityQuery,
         Commodity(commodityCode = "123", description = "test commodity")
       )
       .success
@@ -79,7 +79,7 @@ class CategoryGuidanceControllerSpec extends SpecBase {
       }
     }
 
-    "must redirect to Journey Recover when no commodity code has been provided" in {
+    "must redirect to Journey Recover when no commodity query has been provided" in {
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
         .overrides(

--- a/test/controllers/CategoryGuidanceControllerSpec.scala
+++ b/test/controllers/CategoryGuidanceControllerSpec.scala
@@ -21,7 +21,7 @@ import connectors.OttConnector
 import models.Commodity
 import models.ott.response.{GoodsNomenclatureResponse, OttResponse}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{times, verify, when}
+import org.mockito.Mockito.{never, times, verify, when}
 import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.inject._
 import play.api.test.FakeRequest
@@ -93,6 +93,7 @@ class CategoryGuidanceControllerSpec extends SpecBase {
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+        verify(mockOttConnector, never()).getCategorisationInfo(any())(any())
       }
     }
 

--- a/test/controllers/CategoryGuidanceControllerSpec.scala
+++ b/test/controllers/CategoryGuidanceControllerSpec.scala
@@ -21,7 +21,8 @@ import connectors.OttConnector
 import models.Commodity
 import models.ott.response.{GoodsNomenclatureResponse, OttResponse}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{never, times, verify, when}
+import org.mockito.Mockito.{never, reset, times, verify, when}
+import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.inject._
 import play.api.test.FakeRequest
@@ -32,19 +33,20 @@ import views.html.CategoryGuidanceView
 
 import scala.concurrent.Future
 
-class CategoryGuidanceControllerSpec extends SpecBase {
+class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
 
-  "CategoryGuidance Controller" - {
+  val userAnswersWithCommodity = emptyUserAnswers
+    .set(
+      CommodityQuery,
+      Commodity(commodityCode = "123", description = "test commodity")
+    )
+    .success
+    .value
 
-    val userAnswersWithCommodity = emptyUserAnswers
-      .set(
-        CommodityQuery,
-        Commodity(commodityCode = "123", description = "test commodity")
-      )
-      .success
-      .value
+  val mockOttConnector = mock[OttConnector]
 
-    val mockOttConnector = mock[OttConnector]
+  override def beforeEach(): Unit = {
+    super.beforeEach()
     when(mockOttConnector.getCategorisationInfo(any())(any())).thenReturn(
       Future.successful(
         OttResponse(
@@ -54,6 +56,14 @@ class CategoryGuidanceControllerSpec extends SpecBase {
         )
       )
     )
+  }
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+    reset(mockOttConnector)
+  }
+
+  "CategoryGuidance Controller" - {
 
     "must call OTT and save the response in user answers prior to loading on a GET" in {
 


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/TGP-1073

Ticket says to get category assessments from OTT and save them. 
- Ticket says this should be done when categorise now is pressed, but that is just a page link.
- I make the call when going to categorisation start instead, same effect.
- Uses the commodity query in user answers to call and then set CategorisationQuery.
- Redirect to journey recovery if they end up there without a commodity to categorise
- otherwise, build Nick's categorisation info model from the response from OTT and save it to user answers

Also, I got to enjoy learning about higher order functions :)