### PR TITLE
TGP-846 Create category assessments question page

### DIFF
--- a/app/controllers/AssessmentController.scala
+++ b/app/controllers/AssessmentController.scala
@@ -53,18 +53,18 @@ class AssessmentController @Inject() (
     (identify andThen getData andThen requireData).async { implicit request =>
       val categorisationResult = for {
         userAnswersWithCategorisations <- categorisationService.requireCategorisation(request, recordId)
-        recordQuery <- Future.successful(userAnswersWithCategorisations.get(RecordCategorisationsQuery))
-        categorisationInfo <- Future.fromTry(Try(recordQuery.get.records.get(recordId).get))
+        recordQuery                    <- Future.successful(userAnswersWithCategorisations.get(RecordCategorisationsQuery))
+        categorisationInfo             <- Future.fromTry(Try(recordQuery.get.records.get(recordId).get))
       } yield {
-        val exemptions = categorisationInfo.categoryAssessments(index).exemptions
-        val form = formProvider(exemptions.map(_.id))
+        val exemptions   = categorisationInfo.categoryAssessments(index).exemptions
+        val form         = formProvider(exemptions.map(_.id))
         val preparedForm = userAnswersWithCategorisations.get(AssessmentPage(recordId, index)) match {
           case Some(value) => form.fill(value)
-          case None => form
+          case None        => form
         }
 
         val radioOptions = AssessmentAnswer.radioOptions(exemptions)
-        val viewModel = AssessmentViewModel(
+        val viewModel    = AssessmentViewModel(
           commodityCode = categorisationInfo.commodityCode,
           numberOfThisAssessment = index + 1,
           numberOfAssessments = categorisationInfo.categoryAssessments.size,
@@ -74,11 +74,10 @@ class AssessmentController @Inject() (
         Ok(view(preparedForm, mode, recordId, index, viewModel))
       }
 
-      categorisationResult.recover {
-        case _ => Redirect(routes.JourneyRecoveryController.onPageLoad())
+      categorisationResult.recover { case _ =>
+        Redirect(routes.JourneyRecoveryController.onPageLoad())
       }
     }
-
 
   def onSubmit(mode: Mode, recordId: String, index: Int): Action[AnyContent] =
     (identify andThen getData andThen requireData).async { implicit request =>

--- a/app/controllers/AssessmentController.scala
+++ b/app/controllers/AssessmentController.scala
@@ -22,7 +22,7 @@ import models.{AssessmentAnswer, Mode}
 import navigation.Navigator
 import pages.AssessmentPage
 import play.api.i18n.{I18nSupport, MessagesApi}
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import queries.RecordCategorisationsQuery
 import repositories.SessionRepository
 import services.CategorisationService

--- a/app/controllers/AssessmentController.scala
+++ b/app/controllers/AssessmentController.scala
@@ -58,13 +58,13 @@ class AssessmentController @Inject() (
             categorisationInfo <- recordQuery.records.get(recordId)
           } yield {
 
-            val form = formProvider(categorisationInfo.categoryAssessments.head.exemptions.map(_.id))
+            val form = formProvider(categorisationInfo.categoryAssessments(index).exemptions.map(_.id))
             val preparedForm = request.userAnswers.get(AssessmentPage(recordId, index)) match {
               case Some(value) => form.fill(value)
               case None => form
             }
 
-            val radioOptions = AssessmentAnswer.radioOptions(categorisationInfo.categoryAssessments.head.exemptions)
+            val radioOptions = AssessmentAnswer.radioOptions(categorisationInfo.categoryAssessments(index).exemptions)
             val viewModel = AssessmentViewModel(
               commodityCode = categorisationInfo.commodityCode,
               numberOfThisAssessment = index + 1,

--- a/app/controllers/AssessmentController.scala
+++ b/app/controllers/AssessmentController.scala
@@ -53,7 +53,7 @@ class AssessmentController @Inject() (
     (identify andThen getData andThen requireData).async { implicit request =>
       val categorisationResult = for {
         userAnswersWithCategorisations <- categorisationService.requireCategorisation(request, recordId)
-        recordQuery                    <- Future.successful(userAnswersWithCategorisations.get(RecordCategorisationsQuery))
+        recordQuery                     = userAnswersWithCategorisations.get(RecordCategorisationsQuery)
         categorisationInfo             <- Future.fromTry(Try(recordQuery.get.records.get(recordId).get))
       } yield {
         val exemptions   = categorisationInfo.categoryAssessments(index).exemptions

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -88,23 +88,25 @@ class Navigator @Inject() () {
 
   private def navigateFromAssessment(assessmentPage: AssessmentPage)(answers: UserAnswers): Call = {
     for {
-      recordQuery <- answers.get(RecordCategorisationsQuery)
-      assessmentAnswer   <- answers.get(assessmentPage)
+      recordQuery      <- answers.get(RecordCategorisationsQuery)
+      assessmentAnswer <- answers.get(assessmentPage)
     } yield assessmentAnswer match {
       case AssessmentAnswer.Exemption(_) =>
         val assessmentCount = Try {
           recordQuery.records
             .get(assessmentPage.recordId)
-            .get.categoryAssessments.size
+            .get
+            .categoryAssessments
+            .size
         }.getOrElse(0)
         if (assessmentPage.index + 1 < assessmentCount) {
           routes.AssessmentController.onPageLoad(NormalMode, assessmentPage.recordId, assessmentPage.index + 1)
         } else {
-          // no more assessments left
+          // TODO: no more assessments left
           routes.IndexController.onPageLoad
         }
-      case AssessmentAnswer.NoExemption =>
-        // user answered no to one of them, nick's work
+      case AssessmentAnswer.NoExemption  =>
+        // TODO: user answered no to one of them
         routes.IndexController.onPageLoad
     }
   }.getOrElse(routes.JourneyRecoveryController.onPageLoad())

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -23,6 +23,8 @@ import pages._
 import models._
 import queries.{CategorisationQuery, RecordCategorisationsQuery}
 
+import scala.util.Try
+
 @Singleton
 class Navigator @Inject() () {
 
@@ -90,7 +92,12 @@ class Navigator @Inject() () {
       assessmentAnswer   <- answers.get(assessmentPage)
     } yield assessmentAnswer match {
       case AssessmentAnswer.Exemption(_) =>
-        if (assessmentPage.index + 1 < recordQuery.records.size) {
+        val assessmentCount = Try {
+          recordQuery.records
+            .get(assessmentPage.recordId)
+            .get.categoryAssessments.size
+        }.getOrElse(0)
+        if (assessmentPage.index + 1 < assessmentCount) {
           routes.AssessmentController.onPageLoad(NormalMode, assessmentPage.recordId, assessmentPage.index + 1)
         } else {
           // no more assessments left

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -21,7 +21,7 @@ import play.api.mvc.Call
 import controllers.routes
 import pages._
 import models._
-import queries.{CategorisationQuery, RecordCategorisationsQuery}
+import queries.RecordCategorisationsQuery
 
 import scala.util.Try
 

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -86,17 +86,10 @@ class Navigator @Inject() () {
 
   private def navigateFromAssessment(assessmentPage: AssessmentPage)(answers: UserAnswers): Call = {
     for {
-      categorisationInfo <- answers.get(CategorisationQuery)
-      assessment         <- categorisationInfo.categoryAssessments.find(_.id == assessmentPage.assessmentId)
       assessmentAnswer   <- answers.get(assessmentPage)
-      assessmentIndex     = categorisationInfo.categoryAssessments.indexOf(assessment)
     } yield assessmentAnswer match {
       case AssessmentAnswer.Exemption(_) =>
-        categorisationInfo.categoryAssessments
-          .lift(assessmentIndex + 1)
-          .map(nextAssessment => routes.AssessmentController.onPageLoad(NormalMode, nextAssessment.id))
-          .getOrElse(routes.IndexController.onPageLoad)
-
+        routes.AssessmentController.onPageLoad(NormalMode, assessmentPage.recordId, assessmentPage.index + 1)
       case AssessmentAnswer.NoExemption =>
         routes.IndexController.onPageLoad
     }

--- a/app/pages/AssessmentPage.scala
+++ b/app/pages/AssessmentPage.scala
@@ -33,15 +33,15 @@ case class AssessmentPage(recordId: String, index: Int) extends QuestionPage[Ass
   ): Try[UserAnswers] =
     if (value.contains(AssessmentAnswer.NoExemption)) {
       (for {
-        recordQuery <- updatedUserAnswers.get(RecordCategorisationsQuery)
+        recordQuery        <- updatedUserAnswers.get(RecordCategorisationsQuery)
         categorisationInfo <- recordQuery.records.get(recordId)
-        count = categorisationInfo.categoryAssessments.size
-        rangeToRemove = (index + 1) to count
-      } yield {
-        rangeToRemove.foldLeft[Try[UserAnswers]](Success(updatedUserAnswers)) { (acc, currentIndexToRemove) =>
-          acc.flatMap(_.remove(AssessmentPage(recordId, currentIndexToRemove)))
-        }
-      }).getOrElse(Failure(new InconsistentUserAnswersException(s"Could not find category assessment with index $index")))
+        count               = categorisationInfo.categoryAssessments.size
+        rangeToRemove       = (index + 1) to count
+      } yield rangeToRemove.foldLeft[Try[UserAnswers]](Success(updatedUserAnswers)) { (acc, currentIndexToRemove) =>
+        acc.flatMap(_.remove(AssessmentPage(recordId, currentIndexToRemove)))
+      }).getOrElse(
+        Failure(new InconsistentUserAnswersException(s"Could not find category assessment with index $index"))
+      )
     } else {
       super.cleanup(value, updatedUserAnswers, originalUserAnswers)
     }

--- a/app/pages/AssessmentPage.scala
+++ b/app/pages/AssessmentPage.scala
@@ -18,7 +18,7 @@ package pages
 
 import models.{AssessmentAnswer, UserAnswers}
 import play.api.libs.json.JsPath
-import queries.{CategorisationQuery, RecordCategorisationsQuery}
+import queries.RecordCategorisationsQuery
 
 import scala.util.{Failure, Success, Try}
 

--- a/app/services/CategorisationService.scala
+++ b/app/services/CategorisationService.scala
@@ -46,7 +46,7 @@ class CategorisationService @Inject() (
       case None                                         =>
         for {
           goodsRecord        <- goodsRecordsConnector.getRecord(eori = request.eori, recordId = recordId)
-          goodsNomenclature  <- ottConnector.getCategorisationInfo("0702000007")
+          goodsNomenclature  <- ottConnector.getCategorisationInfo(goodsRecord.commodityCode)
           categorisationInfo <- Future.fromTry(Try(CategorisationInfo.build(goodsNomenclature).get))
           updatedAnswers     <-
             Future.fromTry(

--- a/app/services/CategorisationService.scala
+++ b/app/services/CategorisationService.scala
@@ -46,7 +46,7 @@ class CategorisationService @Inject() (
       case None                                         =>
         for {
           goodsRecord        <- goodsRecordsConnector.getRecord(eori = request.eori, recordId = recordId)
-          goodsNomenclature  <- ottConnector.getCategorisationInfo(goodsRecord.commodityCode)
+          goodsNomenclature  <- ottConnector.getCategorisationInfo("0702000007")
           categorisationInfo <- Future.fromTry(Try(CategorisationInfo.build(goodsNomenclature).get))
           updatedAnswers     <-
             Future.fromTry(

--- a/app/services/CategorisationService.scala
+++ b/app/services/CategorisationService.scala
@@ -46,17 +46,17 @@ class CategorisationService @Inject() (
         Future.successful(request.userAnswers)
       case None                                         =>
         for {
-          goodsRecord        <- goodsRecordsConnector.getRecord(eori = request.eori, recordId = recordId)
-          goodsNomenclature  <- ottConnector.getCategorisationInfo(goodsRecord.commodityCode)
-          categorisationInfo <- Future.fromTry(Try(CategorisationInfo.build(goodsNomenclature).get))
-          updatedAnswers     <-
+          getGoodsRecordResponse <- goodsRecordsConnector.getRecord(eori = request.eori, recordId = recordId)
+          goodsNomenclature      <- ottConnector.getCategorisationInfo(getGoodsRecordResponse.commodityCode)
+          categorisationInfo     <- Future.fromTry(Try(CategorisationInfo.build(goodsNomenclature).get))
+          updatedAnswers         <-
             Future.fromTry(
               request.userAnswers.set(
                 RecordCategorisationsQuery,
                 recordCategorisations.copy(records = recordCategorisations.records + (recordId -> categorisationInfo))
               )
             )
-          _            <- sessionRepository.set(updatedAnswers)
+          _                      <- sessionRepository.set(updatedAnswers)
         } yield updatedAnswers
     }
   }

--- a/app/services/CategorisationService.scala
+++ b/app/services/CategorisationService.scala
@@ -20,7 +20,6 @@ import connectors.{GoodsRecordConnector, OttConnector}
 import models.{RecordCategorisations, UserAnswers}
 import models.ott.CategorisationInfo
 import models.requests.DataRequest
-import org.apache.pekko.Done
 import queries.RecordCategorisationsQuery
 import repositories.SessionRepository
 import uk.gov.hmrc.http.HeaderCarrier

--- a/app/services/CategorisationService.scala
+++ b/app/services/CategorisationService.scala
@@ -56,7 +56,7 @@ class CategorisationService @Inject() (
                 recordCategorisations.copy(records = recordCategorisations.records + (recordId -> categorisationInfo))
               )
             )
-          updated            <- sessionRepository.set(updatedAnswers)
+          _            <- sessionRepository.set(updatedAnswers)
         } yield updatedAnswers
     }
   }

--- a/app/services/CategorisationService.scala
+++ b/app/services/CategorisationService.scala
@@ -35,7 +35,9 @@ class CategorisationService @Inject() (
   goodsRecordsConnector: GoodsRecordConnector
 )(implicit ec: ExecutionContext) {
 
-  def requireCategorisation(request: DataRequest[_], recordId: String)(implicit hc: HeaderCarrier): Future[UserAnswers] = {
+  def requireCategorisation(request: DataRequest[_], recordId: String)(implicit
+    hc: HeaderCarrier
+  ): Future[UserAnswers] = {
 
     val recordCategorisations =
       request.userAnswers.get(RecordCategorisationsQuery).getOrElse(RecordCategorisations(Map.empty))
@@ -46,7 +48,7 @@ class CategorisationService @Inject() (
       case None                                         =>
         for {
           goodsRecord        <- goodsRecordsConnector.getRecord(eori = request.eori, recordId = recordId)
-          goodsNomenclature  <- ottConnector.getCategorisationInfo("0702000007")
+          goodsNomenclature  <- ottConnector.getCategorisationInfo(goodsRecord.commodityCode)
           categorisationInfo <- Future.fromTry(Try(CategorisationInfo.build(goodsNomenclature).get))
           updatedAnswers     <-
             Future.fromTry(
@@ -55,7 +57,7 @@ class CategorisationService @Inject() (
                 recordCategorisations.copy(records = recordCategorisations.records + (recordId -> categorisationInfo))
               )
             )
-          updated                  <- sessionRepository.set(updatedAnswers)
+          updated            <- sessionRepository.set(updatedAnswers)
         } yield updatedAnswers
     }
   }

--- a/app/views/AssessmentView.scala.html
+++ b/app/views/AssessmentView.scala.html
@@ -25,11 +25,11 @@
         govukButton: GovukButton
 )
 
-@(form: Form[_], mode: Mode, assessmentId: String, viewModel: AssessmentViewModel)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], mode: Mode, recordId: String, index: Int, viewModel: AssessmentViewModel)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = title(form, messages("assessment.title", viewModel.numberOfThisAssessment, viewModel.numberOfAssessments))) {
 
-    @formHelper(action = routes.AssessmentController.onSubmit(mode, assessmentId), 'autoComplete -> "off") {
+    @formHelper(action = routes.AssessmentController.onSubmit(mode, recordId, index), 'autoComplete -> "off") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("value" -> "value_0")))

--- a/app/views/AssessmentView.scala.html
+++ b/app/views/AssessmentView.scala.html
@@ -27,7 +27,7 @@
 
 @(form: Form[_], mode: Mode, recordId: String, index: Int, viewModel: AssessmentViewModel)(implicit request: Request[_], messages: Messages)
 
-@layout(pageTitle = title(form, messages("assessment.title", viewModel.numberOfThisAssessment, viewModel.numberOfAssessments))) {
+@layout(pageTitle = title(form, messages("assessment.title"))) {
 
     @formHelper(action = routes.AssessmentController.onSubmit(mode, recordId, index), 'autoComplete -> "off") {
 
@@ -35,7 +35,7 @@
             @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("value" -> "value_0")))
         }
 
-        <h1 class="govuk-heading-l">@messages("assessment.heading", viewModel.numberOfThisAssessment, viewModel.numberOfAssessments)</h1>
+        <h1 class="govuk-heading-l">@messages("assessment.heading", viewModel.numberOfThisAssessment)</h1>
         <p class="govuk-body">@messages("assessment.guidance", viewModel.commodityCode)</p>
         <p class="govuk-body">
             <a href="https://www.trade-tariff.service.gov.uk/find_commodity" class="govuk-link">@messages("assessment.linkText")</a>

--- a/app/views/AssessmentView.scala.html
+++ b/app/views/AssessmentView.scala.html
@@ -37,13 +37,16 @@
 
         <h1 class="govuk-heading-l">@messages("assessment.heading", viewModel.numberOfThisAssessment, viewModel.numberOfAssessments)</h1>
         <p class="govuk-body">@messages("assessment.guidance", viewModel.commodityCode)</p>
+        <p class="govuk-body">
+            <a href="https://www.trade-tariff.service.gov.uk/find_commodity" class="govuk-link">@messages("assessment.linkText")</a>
+        </p>
 
         @govukRadios(
             RadiosViewModel(
                 field  = form("value"),
-                legend = LegendViewModel(messages("assessment.question")).withSize(Medium),
+                legend = LegendViewModel(HtmlContent("<h2 class='govuk-heading-m'>" + messages("assessment.question") + "</h2>")),
                 items  = viewModel.radioOptions
-            ).withHint(HintViewModel(content = "assessment.hint"))
+            )
         )
 
         @govukButton(

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -98,10 +98,10 @@ POST        /create/trader-reference                         controllers.TraderR
 GET         /create/trader-reference/check                   controllers.TraderReferenceController.onPageLoad(mode: Mode = CheckMode)
 POST        /create/trader-reference/check                   controllers.TraderReferenceController.onSubmit(mode: Mode = CheckMode)
 
-GET         /assessment/:id                                  controllers.AssessmentController.onPageLoad(mode: Mode = NormalMode, id: String)
-POST        /assessment/:id                                  controllers.AssessmentController.onSubmit(mode: Mode = NormalMode, id: String)
-GET         /assessment/:id/check                            controllers.AssessmentController.onPageLoad(mode: Mode = CheckMode, id: String)
-POST        /assessment/:id/check                            controllers.AssessmentController.onSubmit(mode: Mode = CheckMode, id: String)
+GET       /update/:recordId/category-assessment/:index       controllers.AssessmentController.onPageLoad(mode: Mode = NormalMode, recordId: String, index: Int)
+POST      /update/:recordId/category-assessment/:index       controllers.AssessmentController.onSubmit(mode: Mode = NormalMode, recordId: String, index: Int)
+GET       /update/:recordId/category-assessment/:index/check controllers.AssessmentController.onPageLoad(mode: Mode = CheckMode, recordId: String, index: Int)
+POST      /update/:recordId/category-assessment/:index/check controllers.AssessmentController.onSubmit(mode: Mode = CheckMode, recordId: String, index: Int)
 
 GET         /ukims-kick-out                                  controllers.UkimsKickOutController.onPageLoad()
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -259,8 +259,9 @@ traderReference.change.hidden = Trader reference
 
 assessment.title = Category assessment {0} of {1}
 assessment.heading = Category assessment {0} of {1}
-assessment.guidance = You need to confirm which of these waivers you hold for {0}. We need this information to be ale to categorise your goods.
-assessment.question = Do you meet one of the following conditions and can supply the relevant document codes on your movements?
+assessment.guidance = You need to confirm which of these conditions you hold for {0}. We need this information to be able to categorise your goods.
+assessment.linkText = Review this code on the Online Tariff Tool (opens in a new tab)
+assessment.question = Do you meet one of the following conditions and can you supply the relevant document code on your movements?
 assessment.hint = Select one answer.
 assessment.exemption = {0} - {1}
 assessment.exemption.none = None of the above

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -258,8 +258,8 @@ traderReference.error.length = Trader reference must be 512 characters or less
 traderReference.checkYourAnswersLabel = Trader reference
 traderReference.change.hidden = Trader reference
 
-assessment.title = Category assessment {0} of {1}
-assessment.heading = Category assessment {0} of {1}
+assessment.title = Categorisation question
+assessment.heading = Category assessment {0}
 assessment.guidance = You need to confirm which of these conditions you hold for {0}. We need this information to be able to categorise your goods.
 assessment.linkText = Review this code on the Online Tariff Tool (opens in a new tab)
 assessment.question = Do you meet one of the following conditions and can you supply the relevant document code on your movements?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -265,6 +265,7 @@ assessment.question = Do you meet one of the following conditions and can you su
 assessment.hint = Select one answer.
 assessment.exemption = {0} - {1}
 assessment.exemption.none = None of the above
+assessment.error.required = Select if you meet a condition
 
 ukimsKickOut.title = You need to apply for the UK Internal Market Scheme (UKIMS)
 ukimsKickOut.h1 = You need to apply for the UK Internal Market Scheme (UKIMS)

--- a/test/controllers/AssessmentControllerSpec.scala
+++ b/test/controllers/AssessmentControllerSpec.scala
@@ -31,7 +31,6 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import queries.{CategorisationQuery, RecordCategorisationsQuery}
 import repositories.SessionRepository
-import services.CategorisationService
 import viewmodels.AssessmentViewModel
 import views.html.AssessmentView
 
@@ -39,13 +38,12 @@ import scala.concurrent.Future
 
 class AssessmentControllerSpec extends SpecBase with MockitoSugar {
 
-  private def onwardRoute               = Call("GET", "/foo")
-  private val formProvider              = new AssessmentFormProvider()
-  private def assessmentId              = "321"
-  private def recordId                  = "1"
-  private def index                     = 0
-  private def assessmentRoute           = routes.AssessmentController.onPageLoad(NormalMode, recordId, index).url
-  private def mockCategorisationService = mock[CategorisationService]
+  private def onwardRoute     = Call("GET", "/foo")
+  private val formProvider    = new AssessmentFormProvider()
+  private def assessmentId    = "321"
+  private def recordId        = "1"
+  private def index           = 0
+  private def assessmentRoute = routes.AssessmentController.onPageLoad(NormalMode, recordId, index).url
 
   "AssessmentController" - {
 

--- a/test/controllers/AssessmentControllerSpec.scala
+++ b/test/controllers/AssessmentControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import base.SpecBase
 import forms.AssessmentFormProvider
-import models.{AssessmentAnswer, NormalMode}
+import models.{AssessmentAnswer, NormalMode, RecordCategorisations}
 import models.ott.{CategorisationInfo, CategoryAssessment, Certificate}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
@@ -29,8 +29,9 @@ import play.api.mvc.Call
 import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import queries.CategorisationQuery
+import queries.{CategorisationQuery, RecordCategorisationsQuery}
 import repositories.SessionRepository
+import services.CategorisationService
 import viewmodels.AssessmentViewModel
 import views.html.AssessmentView
 
@@ -38,10 +39,13 @@ import scala.concurrent.Future
 
 class AssessmentControllerSpec extends SpecBase with MockitoSugar {
 
-  private def onwardRoute     = Call("GET", "/foo")
-  private val formProvider    = new AssessmentFormProvider()
-  private def assessmentId    = "1"
-  private def assessmentRoute = routes.AssessmentController.onPageLoad(NormalMode, assessmentId).url
+  private def onwardRoute               = Call("GET", "/foo")
+  private val formProvider              = new AssessmentFormProvider()
+  private def assessmentId              = "321"
+  private def recordId                  = "1"
+  private def index                     = 0
+  private def assessmentRoute           = routes.AssessmentController.onPageLoad(NormalMode, recordId, index).url
+  private def mockCategorisationService = mock[CategorisationService]
 
   "AssessmentController" - {
 
@@ -51,9 +55,10 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar {
 
         "and has not previously been answered" in {
 
-          val assessment         = CategoryAssessment(assessmentId, 1, Seq(Certificate("1", "code", "description")))
-          val categorisationInfo = CategorisationInfo("123", Seq(assessment))
-          val answers            = emptyUserAnswers.set(CategorisationQuery, categorisationInfo).success.value
+          val assessment            = CategoryAssessment(assessmentId, 1, Seq(Certificate("1", "code", "description")))
+          val categorisationInfo    = CategorisationInfo("123", Seq(assessment))
+          val recordCategorisations = RecordCategorisations(records = Map(recordId -> categorisationInfo))
+          val answers               = emptyUserAnswers.set(RecordCategorisationsQuery, recordCategorisations).success.value
 
           val application = applicationBuilder(userAnswers = Some(answers)).build()
 
@@ -73,7 +78,7 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar {
             )
 
             status(result) mustEqual OK
-            contentAsString(result) mustEqual view(form, NormalMode, assessmentId, viewModel)(
+            contentAsString(result) mustEqual view(form, NormalMode, recordId, index, viewModel)(
               request,
               messages(application)
             ).toString
@@ -82,15 +87,16 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar {
 
         "and has previously been answered" in {
 
-          val assessment         = CategoryAssessment(assessmentId, 1, Seq(Certificate("1", "code", "description")))
-          val categorisationInfo = CategorisationInfo("123", Seq(assessment))
+          val assessment            = CategoryAssessment(assessmentId, 1, Seq(Certificate("1", "code", "description")))
+          val categorisationInfo    = CategorisationInfo("123", Seq(assessment))
+          val recordCategorisations = RecordCategorisations(records = Map(recordId -> categorisationInfo))
 
           val answers =
             emptyUserAnswers
-              .set(CategorisationQuery, categorisationInfo)
+              .set(RecordCategorisationsQuery, recordCategorisations)
               .success
               .value
-              .set(AssessmentPage(assessmentId), AssessmentAnswer.NoExemption)
+              .set(AssessmentPage(recordId, index), AssessmentAnswer.NoExemption)
               .success
               .value
 
@@ -112,7 +118,7 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar {
             )
 
             status(result) mustEqual OK
-            contentAsString(result) mustEqual view(form, NormalMode, assessmentId, viewModel)(
+            contentAsString(result) mustEqual view(form, NormalMode, recordId, index, viewModel)(
               request,
               messages(application)
             ).toString
@@ -136,10 +142,11 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar {
           }
         }
 
-        "when this assessment cannot be found" in {
+        "when this assessment index cannot be found" in {
 
-          val categorisationInfo = CategorisationInfo("123", Nil)
-          val answers            = emptyUserAnswers.set(CategorisationQuery, categorisationInfo).success.value
+          val categorisationInfo    = CategorisationInfo("123", Nil)
+          val recordCategorisations = RecordCategorisations(records = Map(recordId -> categorisationInfo))
+          val answers               = emptyUserAnswers.set(RecordCategorisationsQuery, recordCategorisations).success.value
 
           val application = applicationBuilder(userAnswers = Some(answers)).build()
 
@@ -159,13 +166,14 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar {
 
       "must save the answer and redirect to the next page when a valid value is submitted" in {
 
-        val assessment         = CategoryAssessment(assessmentId, 1, Seq(Certificate("1", "code", "description")))
-        val categorisationInfo = CategorisationInfo("123", Seq(assessment))
+        val assessment            = CategoryAssessment(assessmentId, 1, Seq(Certificate("1", "code", "description")))
+        val categorisationInfo    = CategorisationInfo("123", Seq(assessment))
+        val recordCategorisations = RecordCategorisations(records = Map(recordId -> categorisationInfo))
 
         val mockRepository = mock[SessionRepository]
         when(mockRepository.set(any())).thenReturn(Future.successful(true))
 
-        val answers = emptyUserAnswers.set(CategorisationQuery, categorisationInfo).success.value
+        val answers = emptyUserAnswers.set(RecordCategorisationsQuery, recordCategorisations).success.value
 
         val application =
           applicationBuilder(userAnswers = Some(answers))
@@ -180,7 +188,7 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar {
 
           val result = route(application, request).value
 
-          val expectedAnswers = answers.set(AssessmentPage(assessmentId), AssessmentAnswer.NoExemption).success.value
+          val expectedAnswers = answers.set(AssessmentPage(recordId, index), AssessmentAnswer.NoExemption).success.value
 
           status(result) mustEqual SEE_OTHER
           redirectLocation(result).value mustEqual onwardRoute.url
@@ -190,9 +198,11 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar {
 
       "must return a Bad Request and errors when invalid data is submitted" in {
 
-        val assessment         = CategoryAssessment(assessmentId, 1, Seq(Certificate("1", "code", "description")))
-        val categorisationInfo = CategorisationInfo("123", Seq(assessment))
-        val answers            = emptyUserAnswers.set(CategorisationQuery, categorisationInfo).success.value
+        val assessment            = CategoryAssessment(assessmentId, 1, Seq(Certificate("1", "code", "description")))
+        val categorisationInfo    = CategorisationInfo("123", Seq(assessment))
+        val recordCategorisations = RecordCategorisations(records = Map(recordId -> categorisationInfo))
+
+        val answers = emptyUserAnswers.set(RecordCategorisationsQuery, recordCategorisations).success.value
 
         val application = applicationBuilder(userAnswers = Some(answers)).build()
 
@@ -213,7 +223,7 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar {
           )
 
           status(result) mustEqual BAD_REQUEST
-          contentAsString(result) mustEqual view(boundForm, NormalMode, assessmentId, viewModel)(
+          contentAsString(result) mustEqual view(boundForm, NormalMode, recordId, index, viewModel)(
             request,
             messages(application)
           ).toString

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -325,6 +325,14 @@ class NavigatorSpec extends SpecBase {
             answers
           ) mustEqual routes.IndexController.onPageLoad
         }
+
+        "to Journey Recovery when RecordCategorisationsQuery is not present" in {
+          navigator.nextPage(
+            AssessmentPage(recordId, index),
+            NormalMode,
+            emptyUserAnswers
+          ) mustEqual routes.JourneyRecoveryController.onPageLoad()
+        }
       }
     }
 

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -22,7 +22,7 @@ import controllers.routes
 import pages._
 import models._
 import models.ott.{CategorisationInfo, CategoryAssessment, Certificate}
-import queries.{CategorisationQuery, RecordCategorisationsQuery}
+import queries.RecordCategorisationsQuery
 
 class NavigatorSpec extends SpecBase {
 

--- a/test/pages/AssessmentPageSpec.scala
+++ b/test/pages/AssessmentPageSpec.scala
@@ -21,7 +21,7 @@ import models.ott.{CategorisationInfo, CategoryAssessment, Certificate}
 import org.scalatest.{OptionValues, TryValues}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import queries.{CategorisationQuery, RecordCategorisationsQuery}
+import queries.RecordCategorisationsQuery
 
 class AssessmentPageSpec extends AnyFreeSpec with Matchers with TryValues with OptionValues {
 

--- a/test/pages/AssessmentPageSpec.scala
+++ b/test/pages/AssessmentPageSpec.scala
@@ -16,80 +16,83 @@
 
 package pages
 
-import models.{AssessmentAnswer, UserAnswers}
+import models.{AssessmentAnswer, RecordCategorisations, UserAnswers}
 import models.ott.{CategorisationInfo, CategoryAssessment, Certificate}
 import org.scalatest.{OptionValues, TryValues}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import queries.CategorisationQuery
+import queries.{CategorisationQuery, RecordCategorisationsQuery}
 
 class AssessmentPageSpec extends AnyFreeSpec with Matchers with TryValues with OptionValues {
 
   ".cleanup" - {
 
-    val assessment1        = CategoryAssessment(
+    val assessment1           = CategoryAssessment(
       "id1",
       1,
       Seq(Certificate("cert1", "code1", "description1"), Certificate("cert11", "code11", "description11"))
     )
-    val assessment2        = CategoryAssessment(
+    val assessment2           = CategoryAssessment(
       "id2",
       2,
       Seq(Certificate("cert2", "code2", "description2"), Certificate("cert22", "code22", "description222"))
     )
-    val assessment3        = CategoryAssessment(
+    val assessment3           = CategoryAssessment(
       "id3",
       3,
       Seq(Certificate("cert3", "code3", "description3"), Certificate("cert33", "code33", "description33"))
     )
-    val categorisationInfo = CategorisationInfo("123", Seq(assessment1, assessment2, assessment3))
+    val categorisationInfo    = CategorisationInfo("123", Seq(assessment1, assessment2, assessment3))
+    val recordId              = "321"
+    val index                 = 0
+    val recordCategorisations = RecordCategorisations(records = Map(recordId -> categorisationInfo))
 
     "must not remove any assessments when an assessment is answered with an exemption" in {
 
       val answers =
         UserAnswers("id")
-          .set(CategorisationQuery, categorisationInfo)
+          .set(RecordCategorisationsQuery, recordCategorisations)
           .success
           .value
-          .set(AssessmentPage(assessment1.id), AssessmentAnswer.Exemption("cert1"))
+          .set(AssessmentPage(recordId, index), AssessmentAnswer.Exemption("cert1"))
           .success
           .value
-          .set(AssessmentPage(assessment2.id), AssessmentAnswer.Exemption("cert2"))
+          .set(AssessmentPage(recordId, index + 1), AssessmentAnswer.Exemption("cert2"))
           .success
           .value
-          .set(AssessmentPage(assessment3.id), AssessmentAnswer.Exemption("cert3"))
+          .set(AssessmentPage(recordId, index + 2), AssessmentAnswer.Exemption("cert3"))
           .success
           .value
 
-      val result = answers.set(AssessmentPage(assessment2.id), AssessmentAnswer.Exemption("cert22")).success.value
+      val result = answers.set(AssessmentPage(recordId, index), AssessmentAnswer.Exemption("cert22")).success.value
 
-      result.isDefined(AssessmentPage(assessment1.id)) mustBe true
-      result.isDefined(AssessmentPage(assessment2.id)) mustBe true
-      result.isDefined(AssessmentPage(assessment3.id)) mustBe true
+      result.isDefined(AssessmentPage(recordId, index)) mustBe true
+      result.isDefined(AssessmentPage(recordId, index + 1)) mustBe true
+      result.isDefined(AssessmentPage(recordId, index + 2)) mustBe true
     }
 
     "must remove all assessments later in the list when an assessment is answered with no exemption" in {
 
       val answers =
         UserAnswers("id")
-          .set(CategorisationQuery, categorisationInfo)
+          .set(RecordCategorisationsQuery, recordCategorisations)
           .success
           .value
-          .set(AssessmentPage(assessment1.id), AssessmentAnswer.Exemption("cert1"))
+          .set(AssessmentPage(recordId, index), AssessmentAnswer.Exemption("cert1"))
           .success
           .value
-          .set(AssessmentPage(assessment2.id), AssessmentAnswer.Exemption("cert2"))
+          .set(AssessmentPage(recordId, index + 1), AssessmentAnswer.Exemption("cert2"))
           .success
           .value
-          .set(AssessmentPage(assessment3.id), AssessmentAnswer.Exemption("cert3"))
+          .set(AssessmentPage(recordId, index + 2), AssessmentAnswer.Exemption("cert3"))
           .success
           .value
 
-      val result = answers.set(AssessmentPage(assessment2.id), AssessmentAnswer.NoExemption).success.value
+      val result = answers.set(AssessmentPage(recordId, index + 1), AssessmentAnswer.NoExemption).success.value
 
-      result.isDefined(AssessmentPage(assessment1.id)) mustBe true
-      result.isDefined(AssessmentPage(assessment2.id)) mustBe true
-      result.isDefined(AssessmentPage(assessment3.id)) mustBe false
+      result.isDefined(AssessmentPage(recordId, index)) mustBe true
+      result.isDefined(AssessmentPage(recordId, index + 1)) mustBe true
+      result.isDefined(AssessmentPage(recordId, index + 2)) mustBe false
     }
   }
 }

--- a/test/services/CategorisationServiceSpec.scala
+++ b/test/services/CategorisationServiceSpec.scala
@@ -21,9 +21,8 @@ import connectors.{GoodsRecordConnector, OttConnector}
 import models.ott.CategorisationInfo
 import models.ott.response.{CategoryAssessmentRelationship, GoodsNomenclatureResponse, IncludedElement, OttResponse}
 import models.requests.DataRequest
-import models.{RecordCategorisations, UserAnswers}
+import models.RecordCategorisations
 import models.router.responses.GetGoodsRecordResponse
-import org.apache.pekko.Done
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{never, reset, times, verify, when}
 import org.scalatest.BeforeAndAfterEach

--- a/test/services/CategorisationServiceSpec.scala
+++ b/test/services/CategorisationServiceSpec.scala
@@ -21,7 +21,7 @@ import connectors.{GoodsRecordConnector, OttConnector}
 import models.ott.CategorisationInfo
 import models.ott.response.{CategoryAssessmentRelationship, GoodsNomenclatureResponse, IncludedElement, OttResponse}
 import models.requests.DataRequest
-import models.RecordCategorisations
+import models.{RecordCategorisations, UserAnswers}
 import models.router.responses.GetGoodsRecordResponse
 import org.apache.pekko.Done
 import org.mockito.ArgumentMatchers.any
@@ -77,12 +77,14 @@ class CategorisationServiceSpec extends SpecBase with BeforeAndAfterEach {
 
   "requireCategorisation" - {
 
-    "should store category assessments if they are not present, then return successful Done" in {
-      val mockDataRequest = mock[DataRequest[AnyContent]]
+    "should store category assessments if they are not present, then return successful updated answers" in {
+      val mockDataRequest               = mock[DataRequest[AnyContent]]
       when(mockDataRequest.userAnswers).thenReturn(emptyUserAnswers)
+      val expectedCategorisationInfo    = CategorisationInfo("some comcode", Seq())
+      val expectedRecordCategorisations = RecordCategorisations(records = Map("recordId" -> expectedCategorisationInfo))
 
       val result = await(categorisationService.requireCategorisation(mockDataRequest, "recordId"))
-      result mustBe Done
+      result.get(RecordCategorisationsQuery).get mustBe expectedRecordCategorisations
 
       withClue("Should call the router to get the goods record") {
         verify(mockGoodsRecordsConnector, times(1)).getRecord(any(), any())(any())
@@ -97,9 +99,11 @@ class CategorisationServiceSpec extends SpecBase with BeforeAndAfterEach {
       }
     }
 
-    "should not store category assessments if they are already present, then return successful Done" in {
+    "should not call for category assessments if they are already present, then return successful updated answers" in {
+      val expectedRecordCategorisations = RecordCategorisations(Map("recordId" -> CategorisationInfo("comcode", Seq())))
+
       val userAnswers = emptyUserAnswers
-        .set(RecordCategorisationsQuery, RecordCategorisations(Map("recordId" -> CategorisationInfo("comcode", Seq()))))
+        .set(RecordCategorisationsQuery, expectedRecordCategorisations)
         .success
         .value
 
@@ -107,7 +111,7 @@ class CategorisationServiceSpec extends SpecBase with BeforeAndAfterEach {
       when(mockDataRequest.userAnswers).thenReturn(userAnswers)
 
       val result = await(categorisationService.requireCategorisation(mockDataRequest, "recordId"))
-      result mustBe Done
+      result.get(RecordCategorisationsQuery).get mustBe expectedRecordCategorisations
 
       withClue("Should call the router to get the goods record") {
         verify(mockGoodsRecordsConnector, never()).getRecord(any(), any())(any())


### PR DESCRIPTION
Assessment answers are now found under AssessmentPage(recordId, index).
The recordId relates to the RecordCategorisationsQuery's map of recordid->CategorisationInfo. Index corresponds the the index of the category assessment that the answer is for in CategorisationInfo.categoryAssessments.

I would have done it by assessmentId, but design asked for by index and this was simpler.

---- Old description below:

https://jira.tools.tax.service.gov.uk/browse/TGP-846

Poor description, sorry. I've had an absolute nightmare doing this, but it works and it's tested.

Service now returns useranswers for use.

/update/8ebb6b04-6ab0-4fe2-ad62-e6389a8a204f/category-assessment/0 gets the 0th index category assessment and displays it in the page

Could not just do category-assessment-0 since that is not a path variable OR a path parameter. Needs to be /0 or ?assesment=0

QA won't be able to check until stub data for router (For a GoodsRecord) is sorted out to match OTT.
Manually forcing the categorisation service to us a comcode makes everything work, though.

I've booked off Wednesday onwards so I don't think I can handle an entire rework of this right now, but revisiting this might be sensible in the future... however... it does actually work, which I think is most important.