### PR TITLE
TGP-1518: updated regex to allow number only with dashes

### DIFF
--- a/app/models/StringFieldRegex.scala
+++ b/app/models/StringFieldRegex.scala
@@ -18,7 +18,7 @@ package models
 
 object StringFieldRegex {
   val ukimsNumberRegex: String                    = "^(GB|XI)UKIM[0-9]{12}[0-9]{14}$"
-  val nirmsRegex: String                          = "RMS-?(GB|NI)-?[0-9]{6}"
+  val nirmsRegex: String                          = "RMS-(GB|NI)-[0-9]{6}"
   val niphlRegex: String                          = "^([0-9]{4,6}|[a-zA-Z]{1,2}[0-9]{5})$"
   val commodityCodeFormatRegex: String            = "^([0-9]{6}|[0-9]{8}|[0-9]{10})$"
   val emailRegex: String                          = """^\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$"""

--- a/test/forms/NirmsNumberFormProviderSpec.scala
+++ b/test/forms/NirmsNumberFormProviderSpec.scala
@@ -29,7 +29,7 @@ class NirmsNumberFormProviderSpec extends StringFieldBehaviours {
   val nirmsNumberGenerator: Gen[String] = {
     val regionGen = Gen.oneOf("GB", "NI")
     val digitsGen = Gen.listOfN(6, Gen.numChar).map(_.mkString)
-    val hyphenGen = Gen.oneOf("", "-")
+    val hyphenGen = Gen.oneOf("-")
 
     for {
       region  <- regionGen


### PR DESCRIPTION
Nirms number has been updated to accept only 13 chars (with dashes ) as per API spec - earlier we were allowing without dashes too.