### PR TITLE
TGP-1140: Implement navigation based on assessments/exemptions

### DIFF
--- a/app/controllers/CategoryGuidanceController.scala
+++ b/app/controllers/CategoryGuidanceController.scala
@@ -54,7 +54,7 @@ class CategoryGuidanceController @Inject() (
           val scenario = Scenario.getScenario(categoryRecord)
           val isRedirectScenario = (scenario == StandardNoAssessments || scenario == Category1NoExemptions)
           if (isRedirectScenario) {
-            Future.successful(Redirect(routes.IndexController.onPageLoad.url))
+            Future.successful(Redirect(routes.CategorisationResultController.onPageLoad(recordId, scenario).url))
           } else {
             Future.successful(Ok(view(recordId)))
           }

--- a/app/controllers/CategoryGuidanceController.scala
+++ b/app/controllers/CategoryGuidanceController.scala
@@ -52,8 +52,7 @@ class CategoryGuidanceController @Inject() (
         categorisationInfo <- Future.fromTry(Try(recordCategorisations.records.get(recordId).get))
         scenario = Scenario.getRedirectScenarios(recordCategorisations, categorisationInfo)
       } yield scenario match {
-        case Category1NoExemptions => Redirect(routes.CategorisationResultController.onPageLoad(recordId, scenario).url)
-        case StandardNoAssessments => Redirect(routes.CategorisationResultController.onPageLoad(recordId, scenario).url)
+        case Category1NoExemptions | StandardNoAssessments => Redirect(routes.CategorisationResultController.onPageLoad(recordId, scenario).url)
         case NoRedirectScenario => Ok(view(recordId))
       }).recover {
         case _ => Redirect(routes.JourneyRecoveryController.onPageLoad().url)

--- a/app/controllers/CategoryGuidanceController.scala
+++ b/app/controllers/CategoryGuidanceController.scala
@@ -46,21 +46,21 @@ class CategoryGuidanceController @Inject() (
 
   def onPageLoad(recordId: String): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-          (for {
-            ua <- categorisationService.requireCategorisation(request, recordId)
-            categoryRecordEither = CategoryRecord.build(ua, request.eori, recordId)
-          } yield categoryRecordEither match {
-            case Right(categoryRecord) =>
-              val scenario = Scenario.getScenario(categoryRecord)
-              val isRedirectScenario = (scenario == StandardNoAssessments || scenario == Category1NoExemptions)
-              if (isRedirectScenario) {
-                Future.successful(Redirect(routes.IndexController.onPageLoad.url))
-              } else {
-                Future.successful(Ok(view(recordId)))
-              }
-            case Left(_) =>
-              Future.successful(Redirect(routes.JourneyRecoveryController.onPageLoad().url))
-          }).flatten
+      (for {
+        ua <- categorisationService.requireCategorisation(request, recordId)
+        categoryRecordEither = CategoryRecord.build(ua, request.eori, recordId)
+      } yield categoryRecordEither match {
+        case Right(categoryRecord) =>
+          val scenario = Scenario.getScenario(categoryRecord)
+          val isRedirectScenario = (scenario == StandardNoAssessments || scenario == Category1NoExemptions)
+          if (isRedirectScenario) {
+            Future.successful(Redirect(routes.IndexController.onPageLoad.url))
+          } else {
+            Future.successful(Ok(view(recordId)))
+          }
+        case Left(_) =>
+          Future.successful(Redirect(routes.JourneyRecoveryController.onPageLoad().url))
+      }).flatten
   }
 
   def onSubmit(recordId: String): Action[AnyContent] = (identify andThen getData andThen requireData) {

--- a/app/controllers/CategoryGuidanceController.scala
+++ b/app/controllers/CategoryGuidanceController.scala
@@ -17,11 +17,10 @@
 package controllers
 
 import controllers.actions._
-import models.{Category1NoExemptions, CategoryRecord, GoodsRecord, NormalMode, Scenario, StandardNoAssessments}
+import models.{Category1NoExemptions, CategoryRecord, NormalMode, Scenario, StandardNoAssessments}
 import models.helper.CategorisationUpdate
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import queries.CommodityQuery
 import services.{AuditService, CategorisationService}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.Constants.firstAssessmentIndex
@@ -29,7 +28,6 @@ import views.html.CategoryGuidanceView
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
 
 class CategoryGuidanceController @Inject() (
   override val messagesApi: MessagesApi,

--- a/app/controllers/CategoryGuidanceController.scala
+++ b/app/controllers/CategoryGuidanceController.scala
@@ -50,7 +50,7 @@ class CategoryGuidanceController @Inject() (
         ua <- categorisationService.requireCategorisation(request, recordId)
         recordCategorisations <- Future.fromTry(Try(ua.get(RecordCategorisationsQuery).get))
         categorisationInfo <- Future.fromTry(Try(recordCategorisations.records.get(recordId).get))
-        scenario = Scenario.getRedirectScenarios(recordCategorisations, categorisationInfo)
+        scenario = Scenario.getRedirectScenarios(categorisationInfo)
       } yield scenario match {
         case Category1NoExemptions | StandardNoAssessments => Redirect(routes.CategorisationResultController.onPageLoad(recordId, scenario).url)
         case NoRedirectScenario => Ok(view(recordId))

--- a/app/models/Scenario.scala
+++ b/app/models/Scenario.scala
@@ -32,7 +32,7 @@ case object Category2 extends Scenario
 
 object Scenario {
 
-  def getRedirectScenarios(recordCategorisations: RecordCategorisations, categorisationInfo: CategorisationInfo): Scenario = {
+  def getRedirectScenarios(categorisationInfo: CategorisationInfo): Scenario = {
     val hasCategoryAssessments: Boolean =
       categorisationInfo.categoryAssessments.length >= 1
 

--- a/app/models/Scenario.scala
+++ b/app/models/Scenario.scala
@@ -32,7 +32,12 @@ object Scenario {
     goodsRecord.category match {
       case 1 => Category1
       case 2 => Category2
-      case 3 => Standard
+      case 3 =>
+        if (goodsRecord.answeredAssessmentCount == 0) {
+          StandardNoAssessments
+        } else {
+          Standard
+        }
     }
 
   implicit val jsLiteral: JavascriptLiteral[Scenario] = {

--- a/app/models/Scenario.scala
+++ b/app/models/Scenario.scala
@@ -30,7 +30,12 @@ object Scenario {
 
   def getScenario(goodsRecord: CategoryRecord): Scenario =
     goodsRecord.category match {
-      case 1 => Category1
+      case 1 =>
+        if (goodsRecord.answeredAssessmentCount == 0) {
+          Category1NoExemptions
+        } else {
+          Category1
+        }
       case 2 => Category2
       case 3 =>
         if (goodsRecord.answeredAssessmentCount == 0) {

--- a/app/models/Scenario.scala
+++ b/app/models/Scenario.scala
@@ -16,10 +16,14 @@
 
 package models
 
+import models.ott.CategorisationInfo
+import pages.AssessmentPage
 import play.api.mvc.JavascriptLiteral
+import queries.RecordCategorisationsQuery
 
 sealed trait Scenario
 
+case object NoRedirectScenario extends Scenario
 case object Category1NoExemptions extends Scenario
 case object StandardNoAssessments extends Scenario
 case object Standard extends Scenario
@@ -27,6 +31,31 @@ case object Category1 extends Scenario
 case object Category2 extends Scenario
 
 object Scenario {
+
+  def getRedirectScenarios(userAnswers: UserAnswers, recordId: String): Scenario = {
+    val recordCategorisationsQuery = userAnswers.get(RecordCategorisationsQuery).get
+    val categorisationInfo = recordCategorisationsQuery.records.get(recordId).get
+
+    val hasCategoryAssessments: Boolean =
+      categorisationInfo.categoryAssessments.length >= 1
+
+    val hasCategory1Assessments: Boolean =
+      categorisationInfo.categoryAssessments
+        .filter(_.category == 1)
+        .length >= 1
+
+    val hasCategory1Exemptions: Boolean =
+      categorisationInfo.categoryAssessments
+        .filter(_.category == 1)
+        .flatMap(categoryAssessment => categoryAssessment.exemptions)
+        .length >= 1
+
+    (hasCategoryAssessments, hasCategory1Assessments, hasCategory1Exemptions) match {
+      case (true, true, false) => Category1NoExemptions
+      case (false, false, false) => StandardNoAssessments
+      case (_, _, _) => NoRedirectScenario
+    }
+  }
 
   def getScenario(goodsRecord: CategoryRecord): Scenario =
     goodsRecord.category match {

--- a/app/models/Scenario.scala
+++ b/app/models/Scenario.scala
@@ -17,9 +17,7 @@
 package models
 
 import models.ott.CategorisationInfo
-import pages.AssessmentPage
 import play.api.mvc.JavascriptLiteral
-import queries.RecordCategorisationsQuery
 
 sealed trait Scenario
 
@@ -48,27 +46,17 @@ object Scenario {
         .length >= 1
 
     (hasCategoryAssessments, hasCategory1Assessments, hasCategory1Exemptions) match {
-      case (true, true, false) => Category1NoExemptions
+      case (true, true, false)   => Category1NoExemptions
       case (false, false, false) => StandardNoAssessments
-      case (_, _, _) => NoRedirectScenario
+      case (_, _, _)             => NoRedirectScenario
     }
   }
 
   def getScenario(goodsRecord: CategoryRecord): Scenario =
     goodsRecord.category match {
-      case 1 =>
-        if (goodsRecord.answeredAssessmentCount == 0) {
-          Category1NoExemptions
-        } else {
-          Category1
-        }
+      case 1 => Category1
       case 2 => Category2
-      case 3 =>
-        if (goodsRecord.answeredAssessmentCount == 0) {
-          StandardNoAssessments
-        } else {
-          Standard
-        }
+      case 3 => Standard
     }
 
   implicit val jsLiteral: JavascriptLiteral[Scenario] = {

--- a/app/models/Scenario.scala
+++ b/app/models/Scenario.scala
@@ -32,18 +32,18 @@ object Scenario {
 
   def getRedirectScenarios(categorisationInfo: CategorisationInfo): Scenario = {
     val hasCategoryAssessments: Boolean =
-      categorisationInfo.categoryAssessments.length >= 1
+      categorisationInfo.categoryAssessments.nonEmpty
 
     val hasCategory1Assessments: Boolean =
       categorisationInfo.categoryAssessments
         .filter(_.category == 1)
-        .length >= 1
+        .nonEmpty
 
     val hasCategory1Exemptions: Boolean =
       categorisationInfo.categoryAssessments
         .filter(_.category == 1)
         .flatMap(categoryAssessment => categoryAssessment.exemptions)
-        .length >= 1
+        .nonEmpty
 
     (hasCategoryAssessments, hasCategory1Assessments, hasCategory1Exemptions) match {
       case (true, true, false)   => Category1NoExemptions

--- a/app/models/Scenario.scala
+++ b/app/models/Scenario.scala
@@ -35,15 +35,11 @@ object Scenario {
       categorisationInfo.categoryAssessments.nonEmpty
 
     val hasCategory1Assessments: Boolean =
-      categorisationInfo.categoryAssessments
-        .filter(_.category == 1)
-        .nonEmpty
+      categorisationInfo.categoryAssessments.exists(_.category == 1)
 
     val hasCategory1Exemptions: Boolean =
       categorisationInfo.categoryAssessments
-        .filter(_.category == 1)
-        .flatMap(categoryAssessment => categoryAssessment.exemptions)
-        .nonEmpty
+        .exists(assessment => assessment.category == 1 && assessment.exemptions.nonEmpty)
 
     (hasCategoryAssessments, hasCategory1Assessments, hasCategory1Exemptions) match {
       case (true, true, false)   => Category1NoExemptions

--- a/app/models/Scenario.scala
+++ b/app/models/Scenario.scala
@@ -32,10 +32,7 @@ case object Category2 extends Scenario
 
 object Scenario {
 
-  def getRedirectScenarios(userAnswers: UserAnswers, recordId: String): Scenario = {
-    val recordCategorisationsQuery = userAnswers.get(RecordCategorisationsQuery).get
-    val categorisationInfo = recordCategorisationsQuery.records.get(recordId).get
-
+  def getRedirectScenarios(recordCategorisations: RecordCategorisations, categorisationInfo: CategorisationInfo): Scenario = {
     val hasCategoryAssessments: Boolean =
       categorisationInfo.categoryAssessments.length >= 1
 

--- a/app/views/CategorisationResultView.scala.html
+++ b/app/views/CategorisationResultView.scala.html
@@ -38,7 +38,7 @@
 @paragraphContent = @{
     scenario match {
         case Category1NoExemptions => Some(messages("categorisationResult.Category1NoExemptions.p1"))
-        case StandardNoAssessments => Some(messages("categorisationResult.Category3NoAssessments.p1"))
+        case StandardNoAssessments => Some(messages("categorisationResult.StandardNoAssessments.p1"))
         case Standard => None
         case Category1 => None
         case Category2 => None

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -194,9 +194,12 @@ trait SpecBase
     .success
     .value
 
+  lazy val category1NoExemptions: CategoryAssessment =
+    CategoryAssessment("1azbfb-1-dfsdaf-2", 1, Seq())
+
   private lazy val categoryQueryNoExemptions: CategorisationInfo = CategorisationInfo(
     "1234567890",
-    Seq(category1),
+    Seq(category1NoExemptions),
     Some("Weight, in kilograms")
   )
 

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -165,7 +165,7 @@ trait SpecBase
     Map(testRecordId -> categoryQueryWithEmptyMeasurementUnit)
   )
 
-  lazy val userAnswersForCategorisationCya: UserAnswers = emptyUserAnswers
+  lazy val userAnswersForCategorisation: UserAnswers = emptyUserAnswers
     .set(RecordCategorisationsQuery, recordCategorisations)
     .success
     .value

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -179,6 +179,21 @@ trait SpecBase
     .success
     .value
 
+  private lazy val categoryQueryNoAssessments: CategorisationInfo = CategorisationInfo(
+    "1234567890",
+    Seq(),
+    Some("Weight, in kilograms")
+  )
+
+  lazy val recordCategorisationsNoAssessments: RecordCategorisations = RecordCategorisations(
+    Map(testRecordId -> categoryQueryNoAssessments)
+  )
+
+  lazy val uaForCategorisationStandardNoAssessments: UserAnswers = emptyUserAnswers
+    .set(RecordCategorisationsQuery, recordCategorisationsNoAssessments)
+    .success
+    .value
+
   def messages(app: Application): Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
 
   protected def applicationBuilder(userAnswers: Option[UserAnswers] = None): GuiceApplicationBuilder =

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -194,6 +194,21 @@ trait SpecBase
     .success
     .value
 
+  private lazy val categoryQueryNoExemptions: CategorisationInfo = CategorisationInfo(
+    "1234567890",
+    Seq(category1),
+    Some("Weight, in kilograms")
+  )
+
+  lazy val recordCategorisationsNoExemptions: RecordCategorisations = RecordCategorisations(
+    Map(testRecordId -> categoryQueryNoExemptions)
+  )
+
+  lazy val uaForCategorisationCategory1NoExemptions: UserAnswers = emptyUserAnswers
+    .set(RecordCategorisationsQuery, recordCategorisationsNoExemptions)
+    .success
+    .value
+
   def messages(app: Application): Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
 
   protected def applicationBuilder(userAnswers: Option[UserAnswers] = None): GuiceApplicationBuilder =

--- a/test/controllers/CategoryGuidanceControllerSpec.scala
+++ b/test/controllers/CategoryGuidanceControllerSpec.scala
@@ -78,7 +78,7 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
       }
     }
 
-    "must redirect to JourneyRecover when categorisationRecord model cannot be built from user answers" in {
+    "must redirect to JourneyRecovery when categorisationRecord model cannot be built from user answers" in {
 
       when(categorisationService.requireCategorisation(any(), any())(any())).thenReturn(
         Future.successful(emptyUserAnswers)
@@ -92,7 +92,7 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
 
       running(application) {
         val request = FakeRequest(GET, routes.CategoryGuidanceController.onPageLoad(testRecordId).url)
-        val result = route(application, request).value
+        val result  = route(application, request).value
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).get mustEqual routes.JourneyRecoveryController.onPageLoad().url
       }
@@ -112,9 +112,11 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
 
       running(application) {
         val request = FakeRequest(GET, routes.CategoryGuidanceController.onPageLoad(testRecordId).url)
-        val result = route(application, request).value
+        val result  = route(application, request).value
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).get mustEqual routes.CategorisationResultController.onPageLoad(testRecordId, StandardNoAssessments).url
+        redirectLocation(result).get mustEqual routes.CategorisationResultController
+          .onPageLoad(testRecordId, StandardNoAssessments)
+          .url
       }
     }
 
@@ -132,9 +134,11 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
 
       running(application) {
         val request = FakeRequest(GET, routes.CategoryGuidanceController.onPageLoad(testRecordId).url)
-        val result = route(application, request).value
+        val result  = route(application, request).value
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).get mustEqual routes.CategorisationResultController.onPageLoad(testRecordId, Category1NoExemptions).url
+        redirectLocation(result).get mustEqual routes.CategorisationResultController
+          .onPageLoad(testRecordId, Category1NoExemptions)
+          .url
       }
     }
 

--- a/test/controllers/CategoryGuidanceControllerSpec.scala
+++ b/test/controllers/CategoryGuidanceControllerSpec.scala
@@ -55,6 +55,7 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
   override def afterEach(): Unit = {
     super.afterEach()
     reset(categorisationService)
+    reset(mockGoodsRecordsConnector)
   }
 
   "CategoryGuidance Controller" - {
@@ -146,6 +147,14 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
         redirectLocation(result).get mustEqual routes.CategorisationResultController
           .onPageLoad(testRecordId, StandardNoAssessments)
           .url
+
+        withClue("must make a call to update goodsRecord with category info") {
+          verify(mockGoodsRecordsConnector, times(1)).updateGoodsRecord(
+            any(),
+            any(),
+            any()
+          )(any())
+        }
       }
     }
 
@@ -169,6 +178,14 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
         redirectLocation(result).get mustEqual routes.CategorisationResultController
           .onPageLoad(testRecordId, Category1NoExemptions)
           .url
+
+        withClue("must make a call to update goodsRecord with category info") {
+          verify(mockGoodsRecordsConnector, times(1)).updateGoodsRecord(
+            any(),
+            any(),
+            any()
+          )(any())
+        }
       }
     }
 
@@ -176,7 +193,8 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
 
       val application = applicationBuilder(userAnswers = Some(userAnswersForCategorisation))
         .overrides(
-          bind[CategorisationService].toInstance(categorisationService)
+          bind[CategorisationService].toInstance(categorisationService),
+          bind[GoodsRecordConnector].toInstance(mockGoodsRecordsConnector)
         )
         .build()
 
@@ -189,6 +207,14 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(testRecordId)(request, messages(application)).toString
+      }
+
+      withClue("must NOT make a call to update goodsRecord with category info") {
+        verify(mockGoodsRecordsConnector, never()).updateGoodsRecord(
+          any(),
+          any(),
+          any()
+        )(any())
       }
     }
 

--- a/test/controllers/CategoryGuidanceControllerSpec.scala
+++ b/test/controllers/CategoryGuidanceControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import base.TestConstants.{testEori, testRecordId}
 import connectors.GoodsRecordConnector
 import models.helper.CategorisationUpdate
-import models.{Category1NoExemptions, Commodity, NormalMode, StandardNoAssessments}
+import models.{Category1NoExemptions, NormalMode, StandardNoAssessments}
 import org.apache.pekko.Done
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
@@ -29,18 +29,16 @@ import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.inject._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import queries.CommodityQuery
 import repositories.SessionRepository
 import services.{AuditService, CategorisationService}
 import uk.gov.hmrc.auth.core.AffinityGroup
 import views.html.CategoryGuidanceView
 
-import java.time.Instant
 import scala.concurrent.Future
 
 class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
 
-  private val categorisationService = mock[CategorisationService]
+  private val categorisationService     = mock[CategorisationService]
   private val mockGoodsRecordsConnector = mock[GoodsRecordConnector]
 
   override def beforeEach(): Unit = {
@@ -121,7 +119,7 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
 
       running(application) {
         val request = FakeRequest(GET, routes.CategoryGuidanceController.onPageLoad(testRecordId).url)
-        val result = route(application, request).value
+        val result  = route(application, request).value
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).get mustEqual routes.JourneyRecoveryController.onPageLoad().url
       }

--- a/test/controllers/CategoryGuidanceControllerSpec.scala
+++ b/test/controllers/CategoryGuidanceControllerSpec.scala
@@ -65,7 +65,7 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
 
   "CategoryGuidance Controller" - {
 
-    "must call category guidance service to load and save ott info" in {
+    "must call categorisation service to load and save ott info" in {
 
       val mockSessionRepository = mock[SessionRepository]
       when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
@@ -107,7 +107,7 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
 //      }
 //    }
 
-    "must return OK and the correct view for a GET" in {
+    "must OK with correct view and not redirect on a GET when scenario is NOT Category1NoExemptions or StandardNoAssessments" in {
 
       val application = applicationBuilder(userAnswers = Some(userAnswersWithCommodity))
         .overrides(
@@ -116,14 +116,14 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
         .build()
 
       running(application) {
-        val request = FakeRequest(GET, routes.CategoryGuidanceController.onPageLoad(recordId).url)
+        val request = FakeRequest(GET, routes.CategoryGuidanceController.onPageLoad(testRecordId).url)
 
         val result = route(application, request).value
 
         val view = application.injector.instanceOf[CategoryGuidanceView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(recordId)(request, messages(application)).toString
+        contentAsString(result) mustEqual view(testRecordId)(request, messages(application)).toString
       }
     }
 
@@ -142,12 +142,12 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
         .build()
 
       running(application) {
-        val request = FakeRequest(POST, routes.CategoryGuidanceController.onSubmit(recordId).url)
+        val request = FakeRequest(POST, routes.CategoryGuidanceController.onSubmit(testRecordId).url)
 
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual routes.AssessmentController.onPageLoad(NormalMode, recordId, 0).url
+        redirectLocation(result).value mustEqual routes.AssessmentController.onPageLoad(NormalMode, testRecordId, 0).url
 
         withClue("must call the audit service with the correct details") {
           verify(mockAuditService, times(1))
@@ -155,7 +155,7 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
               eqTo(testEori),
               eqTo(AffinityGroup.Individual),
               eqTo(CategorisationUpdate),
-              eqTo(recordId)
+              eqTo(testRecordId)
             )(any())
         }
       }

--- a/test/controllers/CategoryGuidanceControllerSpec.scala
+++ b/test/controllers/CategoryGuidanceControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import base.SpecBase
-import base.TestConstants.testEori
+import base.TestConstants.{testEori, testRecordId}
 import models.helper.CategorisationUpdate
 import models.{Commodity, NormalMode}
 import org.apache.pekko.Done
@@ -47,12 +47,14 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
     .success
     .value
 
+
+
   private val categorisationService = mock[CategorisationService]
 
   override def beforeEach(): Unit = {
     super.beforeEach()
     when(categorisationService.requireCategorisation(any(), any())(any())).thenReturn(
-      Future.successful(emptyUserAnswers)
+      Future.successful(userAnswersForCategorisation)
     )
   }
 
@@ -63,14 +65,12 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
 
   "CategoryGuidance Controller" - {
 
-    val recordId = "test-record-id"
-
     "must call category guidance service to load and save ott info" in {
 
       val mockSessionRepository = mock[SessionRepository]
       when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
 
-      val application = applicationBuilder(userAnswers = Some(userAnswersWithCommodity))
+      val application = applicationBuilder(userAnswers = Some(userAnswersForCategorisation))
         .overrides(
           bind[CategorisationService].toInstance(categorisationService),
           bind[SessionRepository].toInstance(mockSessionRepository)
@@ -79,7 +79,7 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
 
       running(application) {
 
-        val request = FakeRequest(GET, routes.CategoryGuidanceController.onPageLoad(recordId).url)
+        val request = FakeRequest(GET, routes.CategoryGuidanceController.onPageLoad(testRecordId).url)
         val result  = route(application, request).value
 
         status(result) mustEqual OK
@@ -88,23 +88,24 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
       }
     }
 
-    "must redirect to Journey Recover when no commodity query has been provided" in {
-
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
-        .overrides(
-          bind[CategorisationService].toInstance(categorisationService)
-        )
-        .build()
-
-      running(application) {
-        val request = FakeRequest(GET, routes.CategoryGuidanceController.onPageLoad(recordId).url)
-        val result  = route(application, request).value
-
-        status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
-        verify(categorisationService, never()).requireCategorisation(any(), any())(any())
-      }
-    }
+//    Doesn't apply anymore. We get the comcode elsewhere
+//    "must redirect to Journey Recover when no commodity query has been provided" in {
+//
+//      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
+//        .overrides(
+//          bind[CategorisationService].toInstance(categorisationService)
+//        )
+//        .build()
+//
+//      running(application) {
+//        val request = FakeRequest(GET, routes.CategoryGuidanceController.onPageLoad(recordId).url)
+//        val result  = route(application, request).value
+//
+//        status(result) mustEqual SEE_OTHER
+//        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+//        verify(categorisationService, never()).requireCategorisation(any(), any())(any())
+//      }
+//    }
 
     "must return OK and the correct view for a GET" in {
 

--- a/test/controllers/CategoryGuidanceControllerSpec.scala
+++ b/test/controllers/CategoryGuidanceControllerSpec.scala
@@ -109,6 +109,10 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
 
     "must redirect to CategorisationResult when scenario is StandardNoAssessments" in {
 
+      when(categorisationService.requireCategorisation(any(), any())(any())).thenReturn(
+        Future.successful(uaForCategorisationStandardNoAssessments)
+      )
+
       val application = applicationBuilder(userAnswers = Some(uaForCategorisationStandardNoAssessments))
         .overrides(
           bind[CategorisationService].toInstance(categorisationService)
@@ -120,10 +124,10 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
 
         val result = route(application, request).value
 
-        val view = application.injector.instanceOf[CategoryGuidanceView]
+//        val view = application.injector.instanceOf[CategoryGuidanceView]
 
-        status(result) mustEqual OK
-        contentAsString(result) mustEqual view(testRecordId)(request, messages(application)).toString
+        status(result) mustEqual SEE_OTHER
+//        contentAsString(result) mustEqual view(testRecordId)(request, messages(application)).toString
       }
     }
 

--- a/test/controllers/CategoryGuidanceControllerSpec.scala
+++ b/test/controllers/CategoryGuidanceControllerSpec.scala
@@ -107,6 +107,26 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
 //      }
 //    }
 
+    "must redirect to CategorisationResult when scenario is StandardNoAssessments" in {
+
+      val application = applicationBuilder(userAnswers = Some(uaForCategorisationStandardNoAssessments))
+        .overrides(
+          bind[CategorisationService].toInstance(categorisationService)
+        )
+        .build()
+
+      running(application) {
+        val request = FakeRequest(GET, routes.CategoryGuidanceController.onPageLoad(testRecordId).url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[CategoryGuidanceView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(testRecordId)(request, messages(application)).toString
+      }
+    }
+
     "must OK with correct view and not redirect on a GET when scenario is NOT Category1NoExemptions or StandardNoAssessments" in {
 
       val application = applicationBuilder(userAnswers = Some(userAnswersWithCommodity))

--- a/test/controllers/CategoryGuidanceControllerSpec.scala
+++ b/test/controllers/CategoryGuidanceControllerSpec.scala
@@ -78,7 +78,7 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
       }
     }
 
-    "must redirect to JourneyRecovery when categorisationRecord model cannot be built from user answers" in {
+    "must redirect to JourneyRecovery when determining scenario fails due to invalid user answers" in {
 
       when(categorisationService.requireCategorisation(any(), any())(any())).thenReturn(
         Future.successful(emptyUserAnswers)

--- a/test/controllers/CyaCategorisationControllerSpec.scala
+++ b/test/controllers/CyaCategorisationControllerSpec.scala
@@ -49,7 +49,7 @@ class CyaCategorisationControllerSpec extends SpecBase with SummaryListFluency w
 
         "when all category assessments answered" in {
 
-          val userAnswers = userAnswersForCategorisationCya
+          val userAnswers = userAnswersForCategorisation
 
           val application                      = applicationBuilder(userAnswers = Some(userAnswers)).build()
           implicit val localMessages: Messages = messages(application)
@@ -131,7 +131,7 @@ class CyaCategorisationControllerSpec extends SpecBase with SummaryListFluency w
 
         "when supplementary unit is supplied" in {
 
-          val userAnswers = userAnswersForCategorisationCya
+          val userAnswers = userAnswersForCategorisation
             .set(HasSupplementaryUnitPage(testRecordId), true)
             .success
             .value
@@ -178,7 +178,7 @@ class CyaCategorisationControllerSpec extends SpecBase with SummaryListFluency w
 
         "when supplementary unit is not supplied" in {
 
-          val userAnswers = userAnswersForCategorisationCya
+          val userAnswers = userAnswersForCategorisation
             .set(HasSupplementaryUnitPage(testRecordId), false)
             .success
             .value

--- a/test/models/CategorisationAnswersSpec.scala
+++ b/test/models/CategorisationAnswersSpec.scala
@@ -51,7 +51,7 @@ class CategorisationAnswersSpec extends SpecBase {
       "all assessments are answered and supplementary unit was not asked" in {
 
         val answers =
-          userAnswersForCategorisationCya
+          userAnswersForCategorisation
 
         val result = CategorisationAnswers.build(answers, testRecordId)
 
@@ -63,7 +63,7 @@ class CategorisationAnswersSpec extends SpecBase {
       "and supplementary unit was asked for and the answer was no" in {
 
         val answers =
-          userAnswersForCategorisationCya
+          userAnswersForCategorisation
             .set(HasSupplementaryUnitPage(testRecordId), false)
             .success
             .value
@@ -78,7 +78,7 @@ class CategorisationAnswersSpec extends SpecBase {
       "and supplementary unit was asked for and the answer was yes and it was supplied" in {
 
         val answers =
-          userAnswersForCategorisationCya
+          userAnswersForCategorisation
             .set(HasSupplementaryUnitPage(testRecordId), true)
             .success
             .value
@@ -100,7 +100,7 @@ class CategorisationAnswersSpec extends SpecBase {
       "when the user said they have a supplementary unit but it is missing" in {
 
         val answers =
-          userAnswersForCategorisationCya
+          userAnswersForCategorisation
             .set(HasSupplementaryUnitPage(testRecordId), true)
             .success
             .value
@@ -115,7 +115,7 @@ class CategorisationAnswersSpec extends SpecBase {
       "when the user has a supplementary unit without being asked about it " in {
 
         val answers =
-          userAnswersForCategorisationCya
+          userAnswersForCategorisation
             .set(SupplementaryUnitPage(testRecordId), "42.0")
             .success
             .value


### PR DESCRIPTION
Other pr: https://github.com/hmrc/trader-goods-profiles-stubs/pull/66

https://jira.tools.tax.service.gov.uk/browse/TGP-1140

This ticket basically is to cover these cases after clicking "Categorise Goods Now" or otherwise starting the categorisation journey:

1) There are category 1 assessments that have no exemptions -> `Category1NoExemptions` -> Redirect to `CreateRecordSuccess` and update goodsRecord with cat 1.
2) There are no category assessments whatsoever -> `StandardNoAssessments` -> Redirect to `CreateRecordSuccess` and update goodsRecord with cat 3.
3) Otherwise -> `NoRedirectScenario` -> stay on categorisation start page and continue as normal

In lieu of creating a controller solely for redirecting, I have refactored `CategorisationStartController` to decide whether to redirect. I have also removed code from there and a test which predated our `recordId` way of updating.

You'll notice I've added a scenario called `NoRedirectScenario`, and a new method on `Scenario` called `getRedirectScenarios`. The method will return `NoRedirectScenario` for case (3), otherwise, one of the other two will be returned. `NoRedirectScenario` simply symbolises that we're going to continue as normal and nothing more.
