### PR TITLE
TGP-1182: updated commodity code result

### DIFF
--- a/app/controllers/HasCorrectGoodsController.scala
+++ b/app/controllers/HasCorrectGoodsController.scala
@@ -58,7 +58,7 @@ class HasCorrectGoodsController @Inject() (
       case None            => Redirect(routes.JourneyRecoveryController.onPageLoad().url)
     }
   }
-  // TODO - this is still not functional, it is just to create the url. Implement this properly in UPDATE JOURNEY
+  // TODO - this is still not functional, it is just to create the url. Implement this properly
   def onPageLoadLongerCommodityCode(mode: Mode, recordId: String): Action[AnyContent] =
     (identify andThen getData andThen requireData) { implicit request =>
       val preparedForm = request.userAnswers.get(HasCorrectGoodsPage) match {
@@ -89,7 +89,7 @@ class HasCorrectGoodsController @Inject() (
             } yield Redirect(navigator.nextPage(HasCorrectGoodsPage, mode, updatedAnswers))
         )
   }
-  // TODO - this is still not functional, it is just to create the url. Implement this properly in UPDATE JOURNEY
+  // TODO - this is still not functional, it is just to create the url. Implement this properly
   def onSubmitLongerCommodityCode(mode: Mode, recordId: String): Action[AnyContent] =
     (identify andThen getData andThen requireData).async { implicit request =>
       form

--- a/app/factories/AuditEventFactory.scala
+++ b/app/factories/AuditEventFactory.scala
@@ -85,7 +85,8 @@ case class AuditEventFactory() {
     goodsRecord: GoodsRecord,
     isUsingGoodsDescription: Boolean
   )(implicit hc: HeaderCarrier): DataEvent = {
-    val auditDetails = Map(
+    val commodityDescription = goodsRecord.commodity.descriptions.headOption.getOrElse("null")
+    val auditDetails         = Map(
       "eori"                       -> goodsRecord.eori,
       "affinityGroup"              -> affinityGroup.toString,
       "journey"                    -> journey.toString,
@@ -94,7 +95,7 @@ case class AuditEventFactory() {
       "specifiedGoodsDescription"  -> isUsingGoodsDescription.toString,
       "countryOfOrigin"            -> goodsRecord.countryOfOrigin,
       "commodityCode"              -> goodsRecord.commodity.commodityCode,
-      "commodityDescription"       -> goodsRecord.commodity.description,
+      "commodityDescription"       -> commodityDescription,
       "commodityCodeEffectiveFrom" -> goodsRecord.commodity.validityStartDate.toString,
       "commodityCodeEffectiveTo"   -> goodsRecord.commodity.validityEndDate.map(_.toString).getOrElse("null")
     )
@@ -128,7 +129,8 @@ case class AuditEventFactory() {
     journey: Journey,
     goodsRecord: GoodsRecord
   )(implicit hc: HeaderCarrier): DataEvent = {
-    val auditDetails = Map(
+    val commodityDescription = goodsRecord.commodity.descriptions.headOption.getOrElse("")
+    val auditDetails         = Map(
       "eori"                       -> goodsRecord.eori,
       "affinityGroup"              -> affinityGroup.toString,
       "journey"                    -> journey.toString,
@@ -137,7 +139,7 @@ case class AuditEventFactory() {
       "goodsDescription"           -> goodsRecord.goodsDescription,
       "countryOfOrigin"            -> goodsRecord.countryOfOrigin,
       "commodityCode"              -> goodsRecord.commodity.commodityCode,
-      "commodityDescription"       -> goodsRecord.commodity.description,
+      "commodityDescription"       -> commodityDescription,
       "commodityCodeEffectiveFrom" -> goodsRecord.commodity.validityStartDate.toString,
       "commodityCodeEffectiveTo"   -> goodsRecord.commodity.validityEndDate.map(_.toString).getOrElse("null")
     )
@@ -176,7 +178,7 @@ case class AuditEventFactory() {
         responseStatus.toString,
         errorMessage.getOrElse("null")
       ),
-      commodityDetails.map(_.description).getOrElse("null"),
+      commodityDetails.flatMap(_.descriptions.headOption).getOrElse("null"),
       commodityDetails.flatMap(_.validityEndDate.map(_.toString)).getOrElse("null"),
       commodityDetails.map(_.validityStartDate.toString).getOrElse("null")
     )

--- a/app/factories/AuditEventFactory.scala
+++ b/app/factories/AuditEventFactory.scala
@@ -85,8 +85,7 @@ case class AuditEventFactory() {
     goodsRecord: GoodsRecord,
     isUsingGoodsDescription: Boolean
   )(implicit hc: HeaderCarrier): DataEvent = {
-    val commodityDescription = goodsRecord.commodity.descriptions.headOption.getOrElse("null")
-    val auditDetails         = Map(
+    val auditDetails = Map(
       "eori"                       -> goodsRecord.eori,
       "affinityGroup"              -> affinityGroup.toString,
       "journey"                    -> journey.toString,
@@ -95,7 +94,7 @@ case class AuditEventFactory() {
       "specifiedGoodsDescription"  -> isUsingGoodsDescription.toString,
       "countryOfOrigin"            -> goodsRecord.countryOfOrigin,
       "commodityCode"              -> goodsRecord.commodity.commodityCode,
-      "commodityDescription"       -> commodityDescription,
+      "commodityDescription"       -> goodsRecord.commodity.descriptions.headOption.getOrElse("null"),
       "commodityCodeEffectiveFrom" -> goodsRecord.commodity.validityStartDate.toString,
       "commodityCodeEffectiveTo"   -> goodsRecord.commodity.validityEndDate.map(_.toString).getOrElse("null")
     )
@@ -129,8 +128,7 @@ case class AuditEventFactory() {
     journey: Journey,
     goodsRecord: GoodsRecord
   )(implicit hc: HeaderCarrier): DataEvent = {
-    val commodityDescription = goodsRecord.commodity.descriptions.headOption.getOrElse("")
-    val auditDetails         = Map(
+    val auditDetails = Map(
       "eori"                       -> goodsRecord.eori,
       "affinityGroup"              -> affinityGroup.toString,
       "journey"                    -> journey.toString,
@@ -139,7 +137,7 @@ case class AuditEventFactory() {
       "goodsDescription"           -> goodsRecord.goodsDescription,
       "countryOfOrigin"            -> goodsRecord.countryOfOrigin,
       "commodityCode"              -> goodsRecord.commodity.commodityCode,
-      "commodityDescription"       -> commodityDescription,
+      "commodityDescription"       -> goodsRecord.commodity.descriptions.headOption.getOrElse("null"),
       "commodityCodeEffectiveFrom" -> goodsRecord.commodity.validityStartDate.toString,
       "commodityCodeEffectiveTo"   -> goodsRecord.commodity.validityEndDate.map(_.toString).getOrElse("null")
     )
@@ -178,10 +176,7 @@ case class AuditEventFactory() {
         responseStatus.toString,
         errorMessage
       ),
-      commodityDetails.flatMap(_.descriptions.headOption).getOrElse("null"),
-      commodityDetails.flatMap(_.validityEndDate.map(_.toString)).getOrElse("null"),
-      commodityDetails.map(_.validityStartDate.toString).getOrElse("null")
-      commodityDetails.map(_.description),
+      commodityDetails.flatMap(_.descriptions.headOption),
       // If commodityDetails are defined and no endDate then we got sent a null for this so pass it on.
       commodityDetails.map(_.validityEndDate.map(_.toString).getOrElse("null")),
       commodityDetails.map(_.validityStartDate.toString)
@@ -218,8 +213,8 @@ case class AuditEventFactory() {
         responseStatus.toString,
         errorMessage
       ),
-      ottResponse.map(_.categoryAssessments.size.toString).getOrElse("null"),
-      ottResponse.map(_.categoryAssessments.map(_.exemptions.size).sum.toString).getOrElse("null")
+      ottResponse.map(_.categoryAssessments.size.toString),
+      ottResponse.map(_.categoryAssessments.map(_.exemptions.size).sum.toString)
     )
 
     ExtendedDataEvent(

--- a/app/views/HasCorrectGoodsView.scala.html
+++ b/app/views/HasCorrectGoodsView.scala.html
@@ -35,7 +35,7 @@
 
     <ul class="govuk-body">
         @commodity.descriptions.zipWithIndex.map { case (description, index) =>
-            <li>@messages(description)</li>
+            <li>@messages(description.toLowerCase)</li>
         }
     </ul>
 

--- a/app/views/HasCorrectGoodsView.scala.html
+++ b/app/views/HasCorrectGoodsView.scala.html
@@ -35,7 +35,7 @@
 
     <ul class="govuk-body">
         @commodity.descriptions.zipWithIndex.map { case (description, index) =>
-            <li>@messages(description.toLowerCase)</li>
+            <li>@description.toLowerCase</li>
         }
     </ul>
 

--- a/app/views/HasCorrectGoodsView.scala.html
+++ b/app/views/HasCorrectGoodsView.scala.html
@@ -34,9 +34,9 @@
     <p class="govuk-body">@messages("hasCorrectGoods.p1")</p>
 
     <ul class="govuk-body">
-    @commodity.descriptions.zipWithIndex.map { case (description, index) =>
-    <li>@messages(description)</li>
-    }
+        @commodity.descriptions.zipWithIndex.map { case (description, index) =>
+            <li>@messages(description)</li>
+        }
     </ul>
 
 

--- a/app/views/HasCorrectGoodsView.scala.html
+++ b/app/views/HasCorrectGoodsView.scala.html
@@ -30,10 +30,18 @@
 
     <h1 class="govuk-heading-l">@messages("hasCorrectGoods.heading", commodity.commodityCode)</h1>
 
-    <p class="govuk-body">@messages("hasCorrectGoods.p1", commodity.description)</p>
+
+    <p class="govuk-body">@messages("hasCorrectGoods.p1")</p>
+
+    <ul class="govuk-body">
+    @commodity.descriptions.zipWithIndex.map { case (description, index) =>
+    <li>@messages(description)</li>
+    }
+    </ul>
+
 
     <p class="govuk-body">
-        <a href="https://www.trade-tariff.service.gov.uk/search?q=@commodity.commodityCode" class="govuk-link" >@messages("hasCorrectGoods.p2.linkText")</a>.
+        <a href="https://www.trade-tariff.service.gov.uk/search?q=@commodity.commodityCode" target="_blank" class="govuk-link" >@messages("hasCorrectGoods.p2.linkText")</a>.
     </p>
 
     <h2 class="govuk-heading-m">@messages("hasCorrectGoods.h2")</h2>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -80,15 +80,15 @@ POST        /create-record/commodity-code-result                                
 GET         /create-record/commodity-code-result/check                                      controllers.HasCorrectGoodsController.onPageLoad(mode: Mode = CheckMode)
 POST        /create-record/commodity-code-result/check                                      controllers.HasCorrectGoodsController.onSubmit(mode: Mode = CheckMode)
 
-GET         /update/:recordId/longer-commodity-code-result             controllers.HasCorrectGoodsController.onPageLoadLongerCommodityCode(mode: Mode = NormalMode,recordId: String)
-POST        /update/:recordId/longer-commodity-code-result             controllers.HasCorrectGoodsController.onSubmitLongerCommodityCode(mode: Mode = NormalMode,recordId: String)
-GET         /update/:recordId/longer-commodity-code-result/check       controllers.HasCorrectGoodsController.onPageLoadLongerCommodityCode(mode: Mode = CheckMode,recordId: String)
-POST        /update/:recordId/longer-commodity-code-result/check       controllers.HasCorrectGoodsController.onSubmitLongerCommodityCode(mode: Mode = CheckMode,recordId: String)
+GET         /update/:recordId/longer-commodity-code-result                                  controllers.HasCorrectGoodsController.onPageLoadLongerCommodityCode(mode: Mode = NormalMode,recordId: String)
+POST        /update/:recordId/longer-commodity-code-result                                  controllers.HasCorrectGoodsController.onSubmitLongerCommodityCode(mode: Mode = NormalMode,recordId: String)
+GET         /update/:recordId/longer-commodity-code-result/check                            controllers.HasCorrectGoodsController.onPageLoadLongerCommodityCode(mode: Mode = CheckMode,recordId: String)
+POST        /update/:recordId/longer-commodity-code-result/check                            controllers.HasCorrectGoodsController.onSubmitLongerCommodityCode(mode: Mode = CheckMode,recordId: String)
 
-GET         /create-record/goods-description-question        controllers.UseTraderReferenceController.onPageLoad(mode: Mode = NormalMode)
-POST        /create-record/goods-description-question        controllers.UseTraderReferenceController.onSubmit(mode: Mode = NormalMode)
-GET         /create-record/goods-description-question/check  controllers.UseTraderReferenceController.onPageLoad(mode: Mode = CheckMode)
-POST        /create-record/goods-description-question/check  controllers.UseTraderReferenceController.onSubmit(mode: Mode = CheckMode)
+GET         /create-record/goods-description-question                                       controllers.UseTraderReferenceController.onPageLoad(mode: Mode = NormalMode)
+POST        /create-record/goods-description-question                                       controllers.UseTraderReferenceController.onSubmit(mode: Mode = NormalMode)
+GET         /create-record/goods-description-question/check                                 controllers.UseTraderReferenceController.onPageLoad(mode: Mode = CheckMode)
+POST        /create-record/goods-description-question/check                                 controllers.UseTraderReferenceController.onSubmit(mode: Mode = CheckMode)
 
 GET         /create-record/check-your-answers                                               controllers.CyaCreateRecordController.onPageLoad
 POST        /create-record/check-your-answers                                               controllers.CyaCreateRecordController.onSubmit

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -80,6 +80,11 @@ POST        /create-record/commodity-code-result             controllers.HasCorr
 GET         /create-record/commodity-code-result/check       controllers.HasCorrectGoodsController.onPageLoad(mode: Mode = CheckMode)
 POST        /create-record/commodity-code-result/check       controllers.HasCorrectGoodsController.onSubmit(mode: Mode = CheckMode)
 
+GET         /update/:recordId/longer-commodity-code-result             controllers.HasCorrectGoodsController.onPageLoadLongerCommodityCode(mode: Mode = NormalMode,recordId: String)
+POST        /update/:recordId/longer-commodity-code-result             controllers.HasCorrectGoodsController.onSubmitLongerCommodityCode(mode: Mode = NormalMode,recordId: String)
+GET         /update/:recordId/longer-commodity-code-result/check       controllers.HasCorrectGoodsController.onPageLoadLongerCommodityCode(mode: Mode = CheckMode,recordId: String)
+POST        /update/:recordId/longer-commodity-code-result/check       controllers.HasCorrectGoodsController.onSubmitLongerCommodityCode(mode: Mode = CheckMode,recordId: String)
+
 GET         /create-record/goods-description-question        controllers.UseTraderReferenceController.onPageLoad(mode: Mode = NormalMode)
 POST        /create-record/goods-description-question        controllers.UseTraderReferenceController.onSubmit(mode: Mode = NormalMode)
 GET         /create-record/goods-description-question/check  controllers.UseTraderReferenceController.onPageLoad(mode: Mode = CheckMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -226,8 +226,8 @@ goodsDescription.change.hidden = Goods description
 
 hasCorrectGoods.title = Results for {0}
 hasCorrectGoods.heading = Results for {0}
-hasCorrectGoods.p1 = Classification: {0}
-hasCorrectGoods.p2.linkText = You can check this commodity code on the Online Tariff Tool
+hasCorrectGoods.p1 = Classification:
+hasCorrectGoods.p2.linkText = You can check this commodity code on the Online Tariff Tool (opens in a new tab)
 hasCorrectGoods.h2 = Are these the correct goods?
 hasCorrectGoods.error.required = Select if these are the correct goods
 

--- a/it/test/connectors/GoodsRecordConnectorSpec.scala
+++ b/it/test/connectors/GoodsRecordConnectorSpec.scala
@@ -236,7 +236,7 @@ class GoodsRecordConnectorSpec
     val goodsRecord = GoodsRecord(
       testEori,
       "1",
-      Commodity("2", "desc", instant, None),
+      Commodity("2", List("desc"), instant, None),
       "3",
       "4"
     )

--- a/it/test/connectors/OttConnectorSpec.scala
+++ b/it/test/connectors/OttConnectorSpec.scala
@@ -72,14 +72,25 @@ class OttConnectorSpec
     "must return correct commodity object" - {
 
       "when validity end date is undefined" in {
-        val commodity = Commodity("123456", "Commodity description", Instant.parse("2012-01-01T00:00:00.000Z"), None)
+        val commodity =
+          Commodity(
+            "123456",
+            List("Other", "Prepared explosives, other than propellent powders", "Of cotton"),
+            Instant.parse("2012-01-01T00:00:00.000Z"),
+            None
+          )
 
         wireMockServer.stubFor(
           get(urlEqualTo(s"/xi/api/v2/commodities/123456"))
             .willReturn(
               ok().withBody(
-                "{\n  \"data\": {\n    \"attributes\": {\n      \"description\": \"Commodity description\",\n      \"goods_nomenclature_item_id\":\"123456\",\n" +
-                  "\"validity_start_date\": \"2012-01-01T00:00:00.000Z\",\n            \"validity_end_date\": null }\n  }\n}"
+                "{\n  \"data\": {\n    \"attributes\": {\n      \"description\": \"Other\",\n      \"goods_nomenclature_item_id\":\"123456\",\n" +
+                  "\"validity_start_date\": \"2012-01-01T00:00:00.000Z\",\n            \"validity_end_date\": null }\n  }\n, \"included\": [{\n      \"id\": \"38195\",\n      " +
+                  "\"type\": \"heading\",\n      \"attributes\": {\n        \"goods_nomenclature_item_id\": \"3602000000\",\n        \"description\": \"Prepared explosives, other than propellent powders\",\n        " +
+                  "\"formatted_description\": \"Prepared explosives, other than propellent powders\",\n        \"description_plain\": \"Prepared explosives, other than propellent powders\",\n        " +
+                  "\"validity_start_date\": \"1972-01-01T00:00:00.000Z\",\n        \"validity_end_date\": null\n      }\n    }\n,{\n      \"id\": \"43521\",\n      \"type\": \"commodity\",\n      \"attributes\": {\n        " +
+                  "\"producline_suffix\": \"80\",\n        \"description\": \"Of cotton\",\n        \"number_indents\": 2,\n        \"goods_nomenclature_item_id\": \"6211320000\",\n        \"formatted_description\": \"Of cotton\",\n        " +
+                  "\"description_plain\": \"Of cotton\",\n        \"validity_start_date\": \"1972-01-01T00:00:00.000Z\",\n        \"validity_end_date\": null\n      }\n    }\n  ]\n}"
               )
             )
         )
@@ -97,7 +108,7 @@ class OttConnectorSpec
       "when validity end date is defined" in {
         val commodity = Commodity(
           "123456",
-          "Commodity description",
+          List("Commodity description"),
           Instant.parse("2012-01-01T00:00:00.000Z"),
           Some(Instant.parse("2032-01-01T00:00:00.000Z"))
         )

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -74,7 +74,7 @@ trait SpecBase
 
   def validityStartDate: Instant = Instant.parse("2007-12-03T10:15:30.00Z")
 
-  def testCommodity: Commodity = Commodity("1234567890", "test", validityStartDate, None)
+  def testCommodity: Commodity = Commodity("1234567890", List("test"), validityStartDate, None)
 
   def fullRecordUserAnswers: UserAnswers =
     UserAnswers(userAnswersId)

--- a/test/controllers/CategoryGuidanceControllerSpec.scala
+++ b/test/controllers/CategoryGuidanceControllerSpec.scala
@@ -42,7 +42,7 @@ class CategoryGuidanceControllerSpec extends SpecBase with BeforeAndAfterEach {
   private val userAnswersWithCommodity = emptyUserAnswers
     .set(
       CommodityQuery,
-      Commodity(commodityCode = "123", description = "test commodity", Instant.now, None)
+      Commodity(commodityCode = "123", descriptions = List("test commodity"), Instant.now, None)
     )
     .success
     .value

--- a/test/controllers/CommodityCodeControllerSpec.scala
+++ b/test/controllers/CommodityCodeControllerSpec.scala
@@ -93,7 +93,7 @@ class CommodityCodeControllerSpec extends SpecBase with MockitoSugar {
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
       when(mockOttConnector.getCommodityCode(anyString(), any(), any(), any(), any())(any())) thenReturn Future
         .successful(
-          Commodity("654321", "Description", Instant.now, None)
+          Commodity("654321", List("Class level1 desc", "Class level2 desc", "Class level3 desc"), Instant.now, None)
         )
 
       val application =

--- a/test/controllers/HasCorrectGoodsControllerSpec.scala
+++ b/test/controllers/HasCorrectGoodsControllerSpec.scala
@@ -50,7 +50,7 @@ class HasCorrectGoodsControllerSpec extends SpecBase with MockitoSugar {
 
       val userAnswers =
         emptyUserAnswers
-          .set(CommodityQuery, Commodity("654321", "Description", Instant.now, None))
+          .set(CommodityQuery, Commodity("654321", List("Description", "Other"), Instant.now, None))
           .success
           .value
 
@@ -67,7 +67,7 @@ class HasCorrectGoodsControllerSpec extends SpecBase with MockitoSugar {
         contentAsString(result) mustEqual view(
           form,
           NormalMode,
-          Commodity("654321", "Description", Instant.now, None)
+          Commodity("654321", List("Description", "Other"), Instant.now, None)
         )(
           request,
           messages(application)
@@ -91,7 +91,7 @@ class HasCorrectGoodsControllerSpec extends SpecBase with MockitoSugar {
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val commodity   = Commodity("654321", "Description", Instant.now, None)
+      val commodity   = Commodity("654321", List("Description"), Instant.now, None)
       val userAnswers = emptyUserAnswers
         .set(CommodityQuery, commodity)
         .success
@@ -161,7 +161,7 @@ class HasCorrectGoodsControllerSpec extends SpecBase with MockitoSugar {
 
     "must return a Bad Request and errors when invalid data is submitted" in {
 
-      val commodity = Commodity("654321", "Description", Instant.now, None)
+      val commodity = Commodity("654321", List("Description"), Instant.now, None)
 
       val userAnswers =
         emptyUserAnswers.set(CommodityQuery, commodity).success.value

--- a/test/controllers/LongerCommodityCodeControllerSpec.scala
+++ b/test/controllers/LongerCommodityCodeControllerSpec.scala
@@ -138,7 +138,7 @@ class LongerCommodityCodeControllerSpec extends SpecBase with MockitoSugar {
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
       when(mockOttConnector.getCommodityCode(anyString(), any(), any(), any(), any())(any())) thenReturn Future
         .successful(
-          Commodity("654321", "Description", Instant.now, None)
+          Commodity("654321", List("Description"), Instant.now, None)
         )
 
       val application =

--- a/test/factories/AuditEventFactorySpec.scala
+++ b/test/factories/AuditEventFactorySpec.scala
@@ -137,7 +137,16 @@ class AuditEventFactorySpec extends SpecBase {
           val effectiveFrom = Instant.now
           val effectiveTo   = effectiveFrom.plusSeconds(99)
           val commodity     =
-            Commodity("030821", List("Sea urchins"), effectiveFrom, Some(effectiveTo))
+            Commodity(
+              "030821",
+              List(
+                "Sea urchins",
+                "Live, fresh or chilled",
+                "Aquatic invertebrates other than crustaceans and molluscs "
+              ),
+              effectiveFrom,
+              Some(effectiveTo)
+            )
 
           val result = AuditEventFactory().createSubmitGoodsRecordEventForCreateRecord(
             AffinityGroup.Organisation,
@@ -175,7 +184,16 @@ class AuditEventFactorySpec extends SpecBase {
         "and not specified goods description" in {
 
           val effectiveFrom = Instant.now
-          val commodity     = Commodity("030821", List("Sea urchins"), effectiveFrom, None)
+          val commodity     = Commodity(
+            "030821",
+            List(
+              "Sea urchins",
+              "Live, fresh or chilled",
+              "Aquatic invertebrates other than crustaceans and molluscs "
+            ),
+            effectiveFrom,
+            None
+          )
 
           val result = AuditEventFactory().createSubmitGoodsRecordEventForCreateRecord(
             AffinityGroup.Organisation,
@@ -244,7 +262,16 @@ class AuditEventFactorySpec extends SpecBase {
 
           val effectiveFrom = Instant.now
           val effectiveTo   = effectiveFrom.plusSeconds(99)
-          val commodity     = Commodity("030821", List("Sea urchins"), effectiveFrom, Some(effectiveTo))
+          val commodity     = Commodity(
+            "030821",
+            List(
+              "Sea urchins",
+              "Live, fresh or chilled",
+              "Aquatic invertebrates other than crustaceans and molluscs "
+            ),
+            effectiveFrom,
+            Some(effectiveTo)
+          )
 
           val result = AuditEventFactory().createSubmitGoodsRecordEventForUpdateRecord(
             AffinityGroup.Organisation,

--- a/test/factories/AuditEventFactorySpec.scala
+++ b/test/factories/AuditEventFactorySpec.scala
@@ -136,7 +136,8 @@ class AuditEventFactorySpec extends SpecBase {
 
           val effectiveFrom = Instant.now
           val effectiveTo   = effectiveFrom.plusSeconds(99)
-          val commodity     = Commodity("030821", "Sea urchins", effectiveFrom, Some(effectiveTo))
+          val commodity     =
+            Commodity("030821", List("Sea urchins"), effectiveFrom, Some(effectiveTo))
 
           val result = AuditEventFactory().createSubmitGoodsRecordEventForCreateRecord(
             AffinityGroup.Organisation,
@@ -174,7 +175,7 @@ class AuditEventFactorySpec extends SpecBase {
         "and not specified goods description" in {
 
           val effectiveFrom = Instant.now
-          val commodity     = Commodity("030821", "Sea urchins", effectiveFrom, None)
+          val commodity     = Commodity("030821", List("Sea urchins"), effectiveFrom, None)
 
           val result = AuditEventFactory().createSubmitGoodsRecordEventForCreateRecord(
             AffinityGroup.Organisation,
@@ -243,7 +244,7 @@ class AuditEventFactorySpec extends SpecBase {
 
           val effectiveFrom = Instant.now
           val effectiveTo   = effectiveFrom.plusSeconds(99)
-          val commodity     = Commodity("030821", "Sea urchins", effectiveFrom, Some(effectiveTo))
+          val commodity     = Commodity("030821", List("Sea urchins"), effectiveFrom, Some(effectiveTo))
 
           val result = AuditEventFactory().createSubmitGoodsRecordEventForUpdateRecord(
             AffinityGroup.Organisation,

--- a/test/models/GoodsRecordSpec.scala
+++ b/test/models/GoodsRecordSpec.scala
@@ -28,7 +28,7 @@ import java.time.Instant
 
 class GoodsRecordSpec extends AnyFreeSpec with Matchers with TryValues with OptionValues {
 
-  private val testCommodity = Commodity("1234567890", "test", Instant.now, None)
+  private val testCommodity = Commodity("1234567890", List("test"), Instant.now, None)
 
   ".build" - {
 


### PR DESCRIPTION
- updated the commodity object to receive multiple descriptions (maximum 3)

- **the functionality for  /update/:recordId/longer-commodity-code-result will be a separate ticket as discussed with Amaka so please ignore that in this**

Page:
![image](https://github.com/hmrc/trader-goods-profiles-frontend/assets/158105847/7d42ad1b-28ee-4acf-a2cb-7cdce871659a)

