### PR TITLE
TGP-1554: Change for category result

### DIFF
--- a/app/models/CategoryRecord.scala
+++ b/app/models/CategoryRecord.scala
@@ -92,7 +92,12 @@ object CategoryRecord {
         case _                                   => CATEGORY_2
       }
     } else {
-      STANDARD
+      val category1AssessmentsCount = categorisationInfo.categoryAssessments.count(_.category == 1)
+      if (category1AssessmentsCount != 0 && category2AssessmentsCount == 0) {
+        CATEGORY_2
+      } else {
+        STANDARD
+      }
     }
   }
 
@@ -102,6 +107,7 @@ object CategoryRecord {
     categorisationInfo: CategorisationInfo
   ): Int = {
     val category1AssessmentsCount = categorisationInfo.categoryAssessments.count(_.category == 1)
+
     if (category1AssessmentsCount > 0) {
       answers.getPageValue(
         AssessmentPage(recordId, category1AssessmentsCount - 1)

--- a/app/models/CategoryRecord.scala
+++ b/app/models/CategoryRecord.scala
@@ -107,7 +107,6 @@ object CategoryRecord {
     categorisationInfo: CategorisationInfo
   ): Int = {
     val category1AssessmentsCount = categorisationInfo.categoryAssessments.count(_.category == 1)
-
     if (category1AssessmentsCount > 0) {
       answers.getPageValue(
         AssessmentPage(recordId, category1AssessmentsCount - 1)

--- a/test/models/CategoryRecordSpec.scala
+++ b/test/models/CategoryRecordSpec.scala
@@ -273,7 +273,7 @@ class CategoryRecordSpec extends AnyFreeSpec with Matchers with TryValues with O
         )
       }
 
-      "when recordCategorisations is missing category 2 assessments but completed category 1 so is category 3" in {
+      "when recordCategorisations is missing category 2 assessments but completed category 1 so is category 2" in {
 
         val answers = UserAnswers(userAnswersId)
           .set(RecordCategorisationsQuery, noCategory2RecordCategorisations)
@@ -289,7 +289,7 @@ class CategoryRecordSpec extends AnyFreeSpec with Matchers with TryValues with O
           CategoryRecord(
             testEori,
             testRecordId,
-            3,
+            2,
             1,
             None,
             Some("kg")


### PR DESCRIPTION
This is with relate to https://jira.tools.tax.service.gov.uk/browse/TGP-1139

**Scenario 5**
Given I am on update/:recordId/cya-categorisation
When I select save and continue
And I have provided document codes for category 1 assessments but none for category 2 assessments
And my record has been categorised as category 2
Then I should be navigated to [category confirmation page - result category 2](https://trader-goods-profile-prototype-18527416d281.herokuapp.com/version-4/categorisation-supp-units/categorisation-result-supp-units)

In test data https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?spaceKey=TGP&title=Useful+Test+Data
EORI GB123456789086 commodity code 0702000007 should result Cat 2 (not Cat 1: Amaka to update the Confluence page as per the comments in https://jira.tools.tax.service.gov.uk/browse/TGP-1554) 