### PR TITLE
TGP 1786 No assessments for Cat 2 still shows assessment page

### DIFF
--- a/app/connectors/GoodsRecordConnector.scala
+++ b/app/connectors/GoodsRecordConnector.scala
@@ -43,7 +43,7 @@ class GoodsRecordConnector @Inject() (config: Configuration, httpClient: HttpCli
     url"$dataStoreBaseUrl/trader-goods-profiles-data-store/traders/$eori/records/$recordId"
 
   private def singleGoodsRecordUrl(eori: String, recordId: String) =
-    url"$tgpRouterBaseUrl/trader-goods-profiles-router/traders/$eori/records/$recordId"
+    url"$dataStoreBaseUrl/trader-goods-profiles-data-store/traders/$eori/records/$recordId"
 
   private def goodsRecordUrl(eori: String, recordId: String) =
     url"$dataStoreBaseUrl/trader-goods-profiles-data-store/traders/$eori/records/$recordId"

--- a/app/connectors/GoodsRecordConnector.scala
+++ b/app/connectors/GoodsRecordConnector.scala
@@ -44,7 +44,7 @@ class GoodsRecordConnector @Inject() (config: Configuration, httpClient: HttpCli
     url"$dataStoreBaseUrl/trader-goods-profiles-data-store/traders/$eori/records/$recordId"
 
   private def singleGoodsRecordUrl(eori: String, recordId: String) =
-    url"$dataStoreBaseUrl/trader-goods-profiles-data-store/traders/$eori/records/$recordId"
+    url"$tgpRouterBaseUrl/trader-goods-profiles-router/traders/$eori/records/$recordId"
 
   private def goodsRecordUrl(eori: String, recordId: String) =
     url"$dataStoreBaseUrl/trader-goods-profiles-data-store/traders/$eori/records/$recordId"

--- a/app/controllers/AssessmentController.scala
+++ b/app/controllers/AssessmentController.scala
@@ -45,7 +45,6 @@ class AssessmentController @Inject() (
   requireData: DataRequiredAction,
   formProvider: AssessmentFormProvider,
   categorisationService: CategorisationService,
-  goodsRecordConnector: GoodsRecordConnector,
   val controllerComponents: MessagesControllerComponents,
   view: AssessmentView
 )(implicit ec: ExecutionContext)
@@ -75,7 +74,7 @@ class AssessmentController @Inject() (
         )
 
         if (exemptions.isEmpty) {
-          handleNoExemptions(userAnswersWithCategorisations, recordId, request.eori)
+          Future.successful(Redirect(routes.CyaCategorisationController.onPageLoad(recordId).url))
         } else {
           Future.successful(Ok(view(preparedForm, mode, recordId, index, viewModel)))
         }
@@ -85,18 +84,6 @@ class AssessmentController @Inject() (
         Redirect(routes.JourneyRecoveryController.onPageLoad())
       }
     }
-
-  private def handleNoExemptions(userAnswers: UserAnswers, recordId: String, eori: String)(implicit request: Request[_]): Future[Result] = {
-    CategoryRecord
-      .build(userAnswers, eori, recordId)
-      .map { categoryRecord =>
-        goodsRecordConnector
-          .updateCategoryForGoodsRecord(eori, recordId, categoryRecord)
-          .map { _ =>
-            Redirect(routes.CyaCategorisationController.onPageLoad(recordId).url)
-          }
-      }.getOrElse(Future.successful(Redirect(routes.JourneyRecoveryController.onPageLoad().url)))
-  }
 
 
   def onSubmit(mode: Mode, recordId: String, index: Int): Action[AnyContent] =

--- a/app/models/CategorisationAnswers.scala
+++ b/app/models/CategorisationAnswers.scala
@@ -63,9 +63,13 @@ object CategorisationAnswers {
       categorisationInfo    <- getCategorisationInfoForThisRecord(recordCategorisations, recordId)
       answeredAssessments   <- getAssessmentsFromUserAnswers(categorisationInfo, userAnswers, recordId)
       _                     <- ensureNoExemptionIsOnlyFinalAnswer(answeredAssessments, recordId)
-      _                     <- ensureHaveAnsweredTheRightAmount(answeredAssessments, categorisationInfo.categoryAssessments.size)
+      _                     <- ensureHaveAnsweredTheRightAmount(answeredAssessments, countAssessmentsThatRequireAnswers(categorisationInfo))
       justTheAnswers         = answeredAssessments.map(_.answer)
     } yield justTheAnswers
+
+  private def countAssessmentsThatRequireAnswers(categorisationInfo: CategorisationInfo): Int = {
+    categorisationInfo.categoryAssessments.takeWhile(a => !(a.category == 2 && a.exemptions.isEmpty)).size
+  }
 
   private def getCategorisationInfoForThisRecord(recordCategorisations: RecordCategorisations, recordId: String) =
     recordCategorisations.records

--- a/app/models/CategorisationAnswers.scala
+++ b/app/models/CategorisationAnswers.scala
@@ -67,9 +67,8 @@ object CategorisationAnswers {
       justTheAnswers         = answeredAssessments.map(_.answer)
     } yield justTheAnswers
 
-  private def countAssessmentsThatRequireAnswers(categorisationInfo: CategorisationInfo): Int = {
+  private def countAssessmentsThatRequireAnswers(categorisationInfo: CategorisationInfo): Int =
     categorisationInfo.categoryAssessments.takeWhile(a => !(a.category == 2 && a.exemptions.isEmpty)).size
-  }
 
   private def getCategorisationInfoForThisRecord(recordCategorisations: RecordCategorisations, recordId: String) =
     recordCategorisations.records

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -182,34 +182,38 @@ class Navigator @Inject() () {
       .getOrElse(routes.JourneyRecoveryController.onPageLoad())
 
   private def navigateFromAssessment(assessmentPage: AssessmentPage)(answers: UserAnswers): Call = {
-    val recordId = assessmentPage.recordId
+    if (!assessmentPage.shouldRedirectToCya) {
+      val recordId = assessmentPage.recordId
 
-    for {
-      recordQuery      <- answers.get(RecordCategorisationsQuery)
-      record           <- recordQuery.records.get(recordId)
-      assessmentAnswer <- answers.get(assessmentPage)
-    } yield assessmentAnswer match {
-      case AssessmentAnswer.Exemption(_) =>
-        val assessmentCount = Try {
-          recordQuery.records(recordId).categoryAssessments.size
-        }.getOrElse(0)
+      for {
+        recordQuery      <- answers.get(RecordCategorisationsQuery)
+        record           <- recordQuery.records.get(recordId)
+        assessmentAnswer <- answers.get(assessmentPage)
+      } yield assessmentAnswer match {
+        case AssessmentAnswer.Exemption(_) =>
+          val assessmentCount = Try {
+            recordQuery.records(recordId).categoryAssessments.size
+          }.getOrElse(0)
 
-        if (assessmentPage.index + 1 < assessmentCount) {
-          routes.AssessmentController.onPageLoad(NormalMode, recordId, assessmentPage.index + 1)
-        } else {
-          routes.CyaCategorisationController.onPageLoad(recordId)
-        }
-      case AssessmentAnswer.NoExemption  =>
-        record.categoryAssessments(assessmentPage.index).category match {
-          case 2
-              if commodityCodeSansTrailingZeros(record.commodityCode).length <= 6 &&
-                record.descendantCount != 0 =>
-            routes.LongerCommodityCodeController.onPageLoad(NormalMode, recordId)
-          case 2 if record.measurementUnit.isDefined =>
-            routes.HasSupplementaryUnitController.onPageLoad(NormalMode, recordId)
-          case _                                     =>
+          if (assessmentPage.index + 1 < assessmentCount) {
+            routes.AssessmentController.onPageLoad(NormalMode, recordId, assessmentPage.index + 1)
+          } else {
             routes.CyaCategorisationController.onPageLoad(recordId)
-        }
+          }
+        case AssessmentAnswer.NoExemption  =>
+          record.categoryAssessments(assessmentPage.index).category match {
+            case 2
+                if commodityCodeSansTrailingZeros(record.commodityCode).length <= 6 &&
+                  record.descendantCount != 0 =>
+              routes.LongerCommodityCodeController.onPageLoad(NormalMode, recordId)
+            case 2 if record.measurementUnit.isDefined =>
+              routes.HasSupplementaryUnitController.onPageLoad(NormalMode, recordId)
+            case _                                     =>
+              routes.CyaCategorisationController.onPageLoad(recordId)
+          }
+      }
+    } else {
+      Some(routes.CyaCategorisationController.onPageLoad(assessmentPage.recordId))
     }
   }.getOrElse(routes.JourneyRecoveryController.onPageLoad())
 

--- a/app/pages/AssessmentPage.scala
+++ b/app/pages/AssessmentPage.scala
@@ -22,7 +22,8 @@ import queries.RecordCategorisationsQuery
 
 import scala.util.{Failure, Success, Try}
 
-case class AssessmentPage(recordId: String, index: Int) extends QuestionPage[AssessmentAnswer] {
+case class AssessmentPage(recordId: String, index: Int, shouldRedirectToCya: Boolean = false)
+    extends QuestionPage[AssessmentAnswer] {
 
   override def path: JsPath = JsPath \ "assessments" \ recordId \ index
 
@@ -31,7 +32,7 @@ case class AssessmentPage(recordId: String, index: Int) extends QuestionPage[Ass
     updatedUserAnswers: UserAnswers,
     originalUserAnswers: UserAnswers
   ): Try[UserAnswers] =
-    if (value.contains(AssessmentAnswer.NoExemption)) {
+    if (value.contains(AssessmentAnswer.NoExemption) && !shouldRedirectToCya) {
       (for {
         recordQuery        <- updatedUserAnswers.get(RecordCategorisationsQuery)
         categorisationInfo <- recordQuery.records.get(recordId)

--- a/test/controllers/AssessmentControllerSpec.scala
+++ b/test/controllers/AssessmentControllerSpec.scala
@@ -49,6 +49,34 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar {
 
     "for a GET" - {
 
+      "must redirect" - {
+
+        "to CyaCategorisation if there's a category 2 assessment without possible exemptions" in {
+
+          val assessmentCat2NoExemptions = CategoryAssessment(assessmentId, 2, Seq())
+          val categorisationInfo         =
+            CategorisationInfo("123", Seq(assessmentCat2NoExemptions), Some("Weight, in kilograms"), 0)
+          val recordCategorisations      = RecordCategorisations(records = Map(recordId -> categorisationInfo))
+
+          val answers =
+            emptyUserAnswers
+              .set(RecordCategorisationsQuery, recordCategorisations)
+              .success
+              .value
+
+          val application = applicationBuilder(userAnswers = Some(answers)).build()
+
+          running(application) {
+            val request = FakeRequest(GET, assessmentRoute)
+
+            val result = route(application, request).value
+            status(result) mustEqual SEE_OTHER
+            redirectLocation(result).value mustEqual routes.CyaCategorisationController.onPageLoad(recordId).url
+          }
+        }
+
+      }
+
       "must render the view when an assessment can be found for this id" - {
 
         "and has not previously been answered" in {

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -435,6 +435,21 @@ class NavigatorSpec extends SpecBase {
 
         "must go from an assessment" - {
 
+          "to CyaCategorisation if the page is marked to redirect there" in {
+
+            val answers =
+              emptyUserAnswers
+                .set(RecordCategorisationsQuery, recordCategorisations)
+                .success
+                .value
+
+            navigator.nextPage(
+              AssessmentPage(recordId, indexAssessment1, shouldRedirectToCya = true),
+              NormalMode,
+              answers
+            ) mustEqual routes.CyaCategorisationController.onPageLoad(recordId)
+          }
+
           "to the next assessment when the answer is an exemption and at least one more assessment exists" in {
 
             val answers =


### PR DESCRIPTION
This error appears when clicking "categorise now" apparently this is a known issue and that Liandra is possibly looking at it, but I'll confirm Monday. Swapping out the url from data store to router results is correct behaviour, though I haven't manually tested since merging in main as I thought that would solve the issue.

`'http://localhost:10906/trader-goods-profiles-data-store/traders/GB123456789097/records' returned 404 (Not Found). Response body: '{"statusCode":404,"message":"URI not found","requested":"/trader-goods-profiles-data-store/traders/GB123456789097/records"}'`

Other than that, this appears to work for the bug mentioned in the ticket. Redirects to CYA if the assessment is Cat2 with no assessments. Other no assessment scenarios have been covered by previous tickets I worked on.