### PR TITLE
TGP-1430: Bugfix for longer comcode on back

### DIFF
--- a/app/models/GoodsRecord.scala
+++ b/app/models/GoodsRecord.scala
@@ -71,7 +71,7 @@ object GoodsRecord {
 
   private def getCommodityQuery(answers: UserAnswers, code: String): EitherNec[ValidationError, Commodity] =
     answers.getPageValue(CommodityQuery) match {
-      case Right(commodity) if commodity.commodityCode.startsWith(code) => Right(commodity)
+      case Right(commodity) if commodity.commodityCode.startsWith(code) => Right(commodity.copy(commodityCode = code))
       case Left(errors)                                                 => Left(errors)
       case _                                                            => Left(NonEmptyChain.one(MismatchedPage(CommodityCodePage)))
     }

--- a/test/models/GoodsRecordSpec.scala
+++ b/test/models/GoodsRecordSpec.scala
@@ -29,7 +29,7 @@ import java.time.Instant
 class GoodsRecordSpec extends AnyFreeSpec with Matchers with TryValues with OptionValues {
 
   private val testCommodity    = Commodity("1234567890", List("test"), Instant.now, None)
-  private val shorterCommodity = Commodity("1234560000", List("test"), Instant.now, None)
+  private val shorterCommodity = Commodity("123456", List("test"), Instant.now, None)
 
   ".build" - {
 


### PR DESCRIPTION
Not sure why we use the ott comcode on to goods record, before it was the user inputted one. This effectively reverts that.

There will likely be more bugs but we'll get to that when we get to that...
Seems to work.