### PR TITLE
TGP-1430: Longer Comcode Bugfixes

### DIFF
--- a/app/viewmodels/checkAnswers/LongerCommodityCodeSummary.scala
+++ b/app/viewmodels/checkAnswers/LongerCommodityCodeSummary.scala
@@ -29,12 +29,17 @@ object LongerCommodityCodeSummary {
   def row(answers: UserAnswers, recordId: String)(implicit messages: Messages): Option[SummaryListRow] = {
     val recordCategorisations = answers.get(RecordCategorisationsQuery).getOrElse(RecordCategorisations(Map.empty))
     val categorisationInfoOpt = recordCategorisations.records.get(recordId)
+    val padLength             = 10
+    val originalComcodeOpt    =
+      categorisationInfoOpt.flatMap(_.originalCommodityCode.map(_.padTo(padLength, "0").mkString))
+
     categorisationInfoOpt match {
-      case Some(x) if !x.originalCommodityCode.contains(x.commodityCode) =>
+      case Some(info) if Some(info.commodityCode) != originalComcodeOpt =>
+        print(info)
         Some(
           SummaryListRowViewModel(
             key = "longerCommodityCode.checkYourAnswersLabel",
-            value = ValueViewModel(x.commodityCode),
+            value = ValueViewModel(info.commodityCode),
             actions = Seq(
               ActionItemViewModel(
                 "site.change",
@@ -44,7 +49,7 @@ object LongerCommodityCodeSummary {
             )
           )
         )
-      case _                                                             =>
+      case _                                                            =>
         None
     }
   }

--- a/app/viewmodels/checkAnswers/LongerCommodityCodeSummary.scala
+++ b/app/viewmodels/checkAnswers/LongerCommodityCodeSummary.scala
@@ -35,7 +35,6 @@ object LongerCommodityCodeSummary {
 
     categorisationInfoOpt match {
       case Some(info) if Some(info.commodityCode) != originalComcodeOpt =>
-        print(info)
         Some(
           SummaryListRowViewModel(
             key = "longerCommodityCode.checkYourAnswersLabel",

--- a/app/viewmodels/checkAnswers/LongerCommodityCodeSummary.scala
+++ b/app/viewmodels/checkAnswers/LongerCommodityCodeSummary.scala
@@ -32,9 +32,10 @@ object LongerCommodityCodeSummary {
     val padLength             = 10
     val originalComcodeOpt    =
       categorisationInfoOpt.flatMap(_.originalCommodityCode.map(_.padTo(padLength, "0").mkString))
+    val currentComcodeOpt     = categorisationInfoOpt.map(_.commodityCode.padTo(padLength, "0").mkString)
 
     categorisationInfoOpt match {
-      case Some(info) if Some(info.commodityCode) != originalComcodeOpt =>
+      case Some(info) if currentComcodeOpt != originalComcodeOpt =>
         Some(
           SummaryListRowViewModel(
             key = "longerCommodityCode.checkYourAnswersLabel",
@@ -48,7 +49,7 @@ object LongerCommodityCodeSummary {
             )
           )
         )
-      case _                                                            =>
+      case _                                                     =>
         None
     }
   }

--- a/test/controllers/CyaCategorisationControllerSpec.scala
+++ b/test/controllers/CyaCategorisationControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import base.SpecBase
 import base.TestConstants.{testEori, testRecordId, userAnswersId}
 import connectors.GoodsRecordConnector
-import models.{AssessmentAnswer, Category1, UserAnswers}
+import models.{AssessmentAnswer, Category1, RecordCategorisations, UserAnswers}
 import org.apache.pekko.Done
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{never, times, verify, when}
@@ -40,6 +40,18 @@ import views.html.CyaCategorisationView
 import scala.concurrent.Future
 
 class CyaCategorisationControllerSpec extends SpecBase with SummaryListFluency with MockitoSugar {
+
+  private val shortCommodity                = "654321"
+  private val unchangedCategoryInfo         =
+    categoryQuery.copy(commodityCode = shortCommodity, originalCommodityCode = Some(shortCommodity))
+  private val unchangedCommodity            = RecordCategorisations(
+    Map(testRecordId -> unchangedCategoryInfo)
+  )
+  private val previouslyUpdatedCategoryInfo =
+    categoryQuery.copy(commodityCode = shortCommodity + 1234, originalCommodityCode = Some(shortCommodity))
+  private val previouslyUpdatedCommodity    = RecordCategorisations(
+    Map(testRecordId -> previouslyUpdatedCategoryInfo)
+  )
 
   "CyaCategorisationController" - {
 
@@ -241,6 +253,9 @@ class CyaCategorisationControllerSpec extends SpecBase with SummaryListFluency w
         "when longer commodity code is given" in {
 
           val userAnswers = userAnswersForCategorisation
+            .set(RecordCategorisationsQuery, previouslyUpdatedCommodity)
+            .success
+            .value
             .set(LongerCommodityCodePage(testRecordId), "1234")
             .success
             .value
@@ -274,6 +289,8 @@ class CyaCategorisationControllerSpec extends SpecBase with SummaryListFluency w
               ).flatten
             )
 
+            expectedLongerCommodityList.rows.size mustEqual 1
+
             status(result) mustEqual OK
             contentAsString(result) mustEqual view(
               testRecordId,
@@ -288,8 +305,10 @@ class CyaCategorisationControllerSpec extends SpecBase with SummaryListFluency w
         }
 
         "when longer commodity code is not given" in {
-
           val userAnswers = userAnswersForCategorisation
+            .set(RecordCategorisationsQuery, unchangedCommodity)
+            .success
+            .value
 
           val application                      = applicationBuilder(userAnswers = Some(userAnswers)).build()
           implicit val localMessages: Messages = messages(application)


### PR DESCRIPTION
Bugs were: Longer comcode not populating after coming from CYA, CYA incorrectly populating longer comcode even if it hadn't been answered. Please let me know if you spot any bugs :)

What I did to manually test:

Create record  (Angola for country, 17490 for commode)
“Categorise goods now”
Complete ALL assessments
CYA page shows with no longer commodity code, as expected.
Click change on 3rd assessment
Select no or none of the above
Longer comcode page shows
Enter a longer one (9900 worked for me)
Continue journey
CYA page shows longer comcode, as expected.
Click back until getting to longer comcode page
Longer comcode page now shows previous input, as expected.
Click continue, and redirects to CYA, as expected.
Click change for longer comcode
Longer comcode page still shows previous input, as expected.