### PR TITLE
TGP-2016 Redirect to Longer Commodity Code when Cat2 no exemp and longer comcode is needed

### DIFF
--- a/app/controllers/AssessmentController.scala
+++ b/app/controllers/AssessmentController.scala
@@ -76,15 +76,24 @@ class AssessmentController @Inject() (
 
         val commodityCodeWithoutZeros = commodityCode.reverse.dropWhile(char => char == '0').reverse
 
-        val shouldGoToLongerCommodityCode = exemptions.isEmpty && category == 2 && commodityCodeWithoutZeros.length <= 6 &&
-          categorisationInfo.descendantCount != 0
+        val shouldGoToLongerCommodityCode =
+          exemptions.isEmpty && category == 2 && commodityCodeWithoutZeros.length <= 6 &&
+            categorisationInfo.descendantCount != 0
 
         val shouldGoToCya = exemptions.isEmpty && !shouldGoToLongerCommodityCode
 
         (shouldGoToCya, shouldGoToLongerCommodityCode, shouldDisplayNext) match {
-          case (true, _, _) => Future.successful(Redirect(navigator.nextPage(AssessmentPage(recordId, index, shouldRedirectToCya = true), mode, request.userAnswers)))
-          case (_, true, _) => Future.successful(Redirect(routes.LongerCommodityCodeController.onPageLoad(mode, recordId).url))
-          case (_, _, true) => Future.successful(Redirect(navigator.nextPage(AssessmentPage(recordId, index), mode, request.userAnswers)))
+          case (true, _, _) =>
+            Future.successful(
+              Redirect(
+                navigator
+                  .nextPage(AssessmentPage(recordId, index, shouldRedirectToCya = true), mode, request.userAnswers)
+              )
+            )
+          case (_, true, _) =>
+            Future.successful(Redirect(routes.LongerCommodityCodeController.onPageLoad(mode, recordId).url))
+          case (_, _, true) =>
+            Future.successful(Redirect(navigator.nextPage(AssessmentPage(recordId, index), mode, request.userAnswers)))
           case _            => Future.successful(Ok(view(preparedForm, mode, recordId, index, listItems, commodityCode)))
         }
       }

--- a/app/controllers/AssessmentController.scala
+++ b/app/controllers/AssessmentController.scala
@@ -60,6 +60,7 @@ class AssessmentController @Inject() (
         listItems                       = categorisationInfo.categoryAssessments(index).getExemptionListItems
         commodityCode                   = categorisationInfo.commodityCode
         exemptions                      = categorisationInfo.categoryAssessments(index).exemptions
+        category                        = categorisationInfo.categoryAssessments(index).category
         form                            = formProvider(exemptions.size)
         preparedForm                    = userAnswersWithCategorisations.get(AssessmentPage(recordId, index)) match {
                                             case Some(value) => form.fill(value)
@@ -71,20 +72,20 @@ class AssessmentController @Inject() (
         val hasAssessmentBeenAnswered =
           request.userAnswers.get(AssessmentPage(recordId, index)).exists(_ != NotAnsweredYet)
 
-        if (exemptions.isEmpty) {
-          Future.successful(
-            Redirect(
-              navigator.nextPage(AssessmentPage(recordId, index, shouldRedirectToCya = true), mode, request.userAnswers)
-            )
-          )
-        } else if (areWeRecategorising && hasAssessmentBeenAnswered && mode == NormalMode) {
-          Future.successful(
-            Redirect(
-              navigator.nextPage(AssessmentPage(recordId, index), mode, request.userAnswers)
-            )
-          )
-        } else {
-          Future.successful(Ok(view(preparedForm, mode, recordId, index, listItems, commodityCode)))
+        val shouldDisplayNext = areWeRecategorising && hasAssessmentBeenAnswered && mode == NormalMode
+
+        val commodityCodeWithoutZeros = commodityCode.reverse.dropWhile(char => char == '0').reverse
+
+        val shouldGoToLongerCommodityCode = exemptions.isEmpty && category == 2 && commodityCodeWithoutZeros.length <= 6 &&
+          categorisationInfo.descendantCount != 0
+
+        val shouldGoToCya = exemptions.isEmpty && !shouldGoToLongerCommodityCode
+
+        (shouldGoToCya, shouldGoToLongerCommodityCode, shouldDisplayNext) match {
+          case (true, _, _) => Future.successful(Redirect(navigator.nextPage(AssessmentPage(recordId, index, shouldRedirectToCya = true), mode, request.userAnswers)))
+          case (_, true, _) => Future.successful(Redirect(routes.LongerCommodityCodeController.onPageLoad(mode, recordId).url))
+          case (_, _, true) => Future.successful(Redirect(navigator.nextPage(AssessmentPage(recordId, index), mode, request.userAnswers)))
+          case _            => Future.successful(Ok(view(preparedForm, mode, recordId, index, listItems, commodityCode)))
         }
       }
 

--- a/test/controllers/AssessmentControllerSpec.scala
+++ b/test/controllers/AssessmentControllerSpec.scala
@@ -51,12 +51,14 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar {
 
       "must redirect" - {
 
-        "to CyaCategorisation if there's a category 2 assessment without possible exemptions" in {
+        "to LongerCommodityCode if there's a cat 2 assessment without exemptions, the commodity code's short, and there are descendants" in {
 
+          val commodityCode = "1234560"
+          val descendantCount = 1
           val assessmentCat2NoExemptions = CategoryAssessment(assessmentId, 2, Seq())
-          val categorisationInfo         =
-            CategorisationInfo("123", Seq(assessmentCat2NoExemptions), Some("Weight, in kilograms"), 0)
-          val recordCategorisations      = RecordCategorisations(records = Map(recordId -> categorisationInfo))
+          val categorisationInfo =
+            CategorisationInfo(commodityCode, Seq(assessmentCat2NoExemptions), Some("Weight, in kilograms"), descendantCount)
+          val recordCategorisations = RecordCategorisations(records = Map(recordId -> categorisationInfo))
 
           val answers =
             emptyUserAnswers
@@ -71,7 +73,41 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar {
 
             val result = route(application, request).value
             status(result) mustEqual SEE_OTHER
-            redirectLocation(result).value mustEqual routes.CyaCategorisationController.onPageLoad(recordId).url
+            redirectLocation(result).value mustEqual routes.LongerCommodityCodeController.onPageLoad(NormalMode, recordId).url
+          }
+        }
+
+        "to CyaCategorisation if there's a cat 2 assessment without exemptions and the user's not being redirected to LongerCommodityCode" in {
+
+          val scenarios = Seq(
+            ("12345600", 0), // short comcode, no descendants
+            ("1234567800", 0), // long comcode, no descendants
+            ("1234567800", 1) // long comcode, with descendants
+          )
+
+          scenarios.map { scenario =>
+            val commodityCode = scenario._1
+            val descendantCount = scenario._2
+            val assessmentCat2NoExemptions = CategoryAssessment(assessmentId, 2, Seq())
+            val categorisationInfo =
+              CategorisationInfo(commodityCode, Seq(assessmentCat2NoExemptions), Some("Weight, in kilograms"), descendantCount)
+            val recordCategorisations = RecordCategorisations(records = Map(recordId -> categorisationInfo))
+
+            val answers =
+              emptyUserAnswers
+                .set(RecordCategorisationsQuery, recordCategorisations)
+                .success
+                .value
+
+            val application = applicationBuilder(userAnswers = Some(answers)).build()
+
+            running(application) {
+              val request = FakeRequest(GET, assessmentRoute)
+
+              val result = route(application, request).value
+              status(result) mustEqual SEE_OTHER
+              redirectLocation(result).value mustEqual routes.CyaCategorisationController.onPageLoad(recordId).url
+            }
           }
         }
 

--- a/test/controllers/AssessmentControllerSpec.scala
+++ b/test/controllers/AssessmentControllerSpec.scala
@@ -53,12 +53,17 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar {
 
         "to LongerCommodityCode if there's a cat 2 assessment without exemptions, the commodity code's short, and there are descendants" in {
 
-          val commodityCode = "1234560"
-          val descendantCount = 1
+          val commodityCode              = "1234560"
+          val descendantCount            = 1
           val assessmentCat2NoExemptions = CategoryAssessment(assessmentId, 2, Seq())
-          val categorisationInfo =
-            CategorisationInfo(commodityCode, Seq(assessmentCat2NoExemptions), Some("Weight, in kilograms"), descendantCount)
-          val recordCategorisations = RecordCategorisations(records = Map(recordId -> categorisationInfo))
+          val categorisationInfo         =
+            CategorisationInfo(
+              commodityCode,
+              Seq(assessmentCat2NoExemptions),
+              Some("Weight, in kilograms"),
+              descendantCount
+            )
+          val recordCategorisations      = RecordCategorisations(records = Map(recordId -> categorisationInfo))
 
           val answers =
             emptyUserAnswers
@@ -73,7 +78,9 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar {
 
             val result = route(application, request).value
             status(result) mustEqual SEE_OTHER
-            redirectLocation(result).value mustEqual routes.LongerCommodityCodeController.onPageLoad(NormalMode, recordId).url
+            redirectLocation(result).value mustEqual routes.LongerCommodityCodeController
+              .onPageLoad(NormalMode, recordId)
+              .url
           }
         }
 
@@ -86,12 +93,17 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar {
           )
 
           scenarios.map { scenario =>
-            val commodityCode = scenario._1
-            val descendantCount = scenario._2
+            val commodityCode              = scenario._1
+            val descendantCount            = scenario._2
             val assessmentCat2NoExemptions = CategoryAssessment(assessmentId, 2, Seq())
-            val categorisationInfo =
-              CategorisationInfo(commodityCode, Seq(assessmentCat2NoExemptions), Some("Weight, in kilograms"), descendantCount)
-            val recordCategorisations = RecordCategorisations(records = Map(recordId -> categorisationInfo))
+            val categorisationInfo         =
+              CategorisationInfo(
+                commodityCode,
+                Seq(assessmentCat2NoExemptions),
+                Some("Weight, in kilograms"),
+                descendantCount
+              )
+            val recordCategorisations      = RecordCategorisations(records = Map(recordId -> categorisationInfo))
 
             val answers =
               emptyUserAnswers


### PR DESCRIPTION
Here's what a user might do:

- Create record
- Categorise now
- Answer all questions prior to the category 2 assessment without an exemption
- IF AND ONLY IF there are descendants and the commodity code is short (in other words, if the current code is NOT the bottom level) then redirect them to enter a longer commodity code.

Please note:

- There is stub data alongside this work: https://github.com/hmrc/trader-goods-profiles-stubs/pull/95 (Comcodes 170491 & 17049199)
- Since we will refactor next sprint, I have abandoned attempts to butcher the Navigator once again. I think this is fine since it will all be replaced.

