### PR TITLE
TGP-1817: success banner for supp unit

### DIFF
--- a/app/controllers/AdviceStartController.scala
+++ b/app/controllers/AdviceStartController.scala
@@ -23,7 +23,7 @@ import pages.AdviceStartPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import utils.SessionData.{dataUpdated, pageUpdated}
+import utils.SessionData.{dataRemoved, dataUpdated, pageUpdated}
 import views.html.AdviceStartView
 
 import javax.inject.Inject
@@ -42,7 +42,7 @@ class AdviceStartController @Inject() (
 
   def onPageLoad(recordId: String): Action[AnyContent] =
     (identify andThen profileAuth andThen getData andThen requireData) { implicit request =>
-      Ok(view(recordId)).removingFromSession(dataUpdated, pageUpdated)
+      Ok(view(recordId)).removingFromSession(dataUpdated, pageUpdated, dataRemoved)
     }
 
   def onSubmit(recordId: String): Action[AnyContent] = (identify andThen getData andThen requireData) {

--- a/app/controllers/CategoryGuidanceController.scala
+++ b/app/controllers/CategoryGuidanceController.scala
@@ -28,7 +28,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import queries.RecordCategorisationsQuery
 import services.{AuditService, CategorisationService}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import utils.SessionData.{dataUpdated, pageUpdated}
+import utils.SessionData.{dataRemoved, dataUpdated, pageUpdated}
 import views.html.CategoryGuidanceView
 
 import javax.inject.Inject
@@ -68,12 +68,12 @@ class CategoryGuidanceController @Inject() (
                     .updateCategoryAndComcodeForGoodsRecord(request.eori, recordId, categoryRecord)
                     .map { _ =>
                       Redirect(routes.CategorisationResultController.onPageLoad(recordId, scenario.get).url)
-                        .removingFromSession(dataUpdated, pageUpdated)
+                        .removingFromSession(dataUpdated, pageUpdated, dataRemoved)
                     }
                 }
                 .getOrElse(Future.successful(Redirect(routes.JourneyRecoveryController.onPageLoad().url)))
             case Some(NoRedirectScenario)                            =>
-              Future.successful(Ok(view(recordId)).removingFromSession(dataUpdated, pageUpdated))
+              Future.successful(Ok(view(recordId)).removingFromSession(dataUpdated, pageUpdated, dataRemoved))
           }
         }
         .recover { e =>

--- a/app/controllers/CommodityCodeController.scala
+++ b/app/controllers/CommodityCodeController.scala
@@ -75,7 +75,7 @@ class CommodityCodeController @Inject() (
 
       val onSubmitAction: Call = routes.CommodityCodeController.onSubmitUpdate(mode, recordId)
 
-      Ok(view(preparedForm, onSubmitAction))
+      Ok(view(preparedForm, onSubmitAction)).removingFromSession(dataRemoved, dataUpdated, pageUpdated)
     }
 
   def onSubmitCreate(mode: Mode): Action[AnyContent] =

--- a/app/controllers/GoodsDescriptionController.scala
+++ b/app/controllers/GoodsDescriptionController.scala
@@ -85,7 +85,7 @@ class GoodsDescriptionController @Inject() (
 
       val submitAction = routes.GoodsDescriptionController.onSubmitUpdate(mode, recordId)
 
-      Ok(view(preparedForm, mode, submitAction))
+      Ok(view(preparedForm, mode, submitAction)).removingFromSession(dataRemoved, dataUpdated, pageUpdated)
     }
 
   def onSubmitUpdate(mode: Mode, recordId: String): Action[AnyContent] =

--- a/app/controllers/GoodsRecordsController.scala
+++ b/app/controllers/GoodsRecordsController.scala
@@ -26,7 +26,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import utils.SessionData.{dataUpdated, pageUpdated}
+import utils.SessionData.{dataRemoved, dataUpdated, pageUpdated}
 import views.html.{GoodsRecordsEmptyView, GoodsRecordsView}
 
 import javax.inject.Inject
@@ -80,13 +80,13 @@ class GoodsRecordsController @Inject() (
                       ),
                       page
                     )
-                  ).removingFromSession(dataUpdated, pageUpdated)
+                  ).removingFromSession(dataUpdated, pageUpdated, dataRemoved)
                 }
               }
             } else {
               Future.successful(
                 Ok(emptyView())
-                  .removingFromSession(dataUpdated, pageUpdated)
+                  .removingFromSession(dataUpdated, pageUpdated, dataRemoved)
               )
             }
           case None                      =>

--- a/app/controllers/HasCommodityCodeChangeController.scala
+++ b/app/controllers/HasCommodityCodeChangeController.scala
@@ -29,6 +29,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import services.AuditService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.SessionData.{dataRemoved, dataUpdated, pageUpdated}
 import views.html.HasCommodityCodeChangeView
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -58,7 +59,7 @@ class HasCommodityCodeChangeController @Inject() (
         case Some(value) => form.fill(value)
       }
 
-      Ok(view(preparedForm, mode, recordId))
+      Ok(view(preparedForm, mode, recordId)).removingFromSession(dataRemoved, dataUpdated, pageUpdated)
     }
 
   def onSubmit(mode: Mode, recordId: String): Action[AnyContent] =

--- a/app/controllers/HasCountryOfOriginChangeController.scala
+++ b/app/controllers/HasCountryOfOriginChangeController.scala
@@ -29,6 +29,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import services.AuditService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.SessionData.{dataRemoved, dataUpdated, pageUpdated}
 import views.html.HasCountryOfOriginChangeView
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -58,7 +59,7 @@ class HasCountryOfOriginChangeController @Inject() (
         case Some(value) => form.fill(value)
       }
 
-      Ok(view(preparedForm, mode, recordId))
+      Ok(view(preparedForm, mode, recordId)).removingFromSession(dataRemoved, dataUpdated, pageUpdated)
     }
 
   def onSubmit(mode: Mode, recordId: String): Action[AnyContent] =

--- a/app/controllers/HasGoodsDescriptionChangeController.scala
+++ b/app/controllers/HasGoodsDescriptionChangeController.scala
@@ -29,6 +29,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import services.AuditService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.SessionData.{dataRemoved, dataUpdated, pageUpdated}
 import views.html.HasGoodsDescriptionChangeView
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -58,7 +59,7 @@ class HasGoodsDescriptionChangeController @Inject() (
         case Some(value) => form.fill(value)
       }
 
-      Ok(view(preparedForm, mode, recordId))
+      Ok(view(preparedForm, mode, recordId)).removingFromSession(dataRemoved, dataUpdated, pageUpdated)
     }
 
   def onSubmit(mode: Mode, recordId: String): Action[AnyContent] =

--- a/app/controllers/HasSupplementaryUnitController.scala
+++ b/app/controllers/HasSupplementaryUnitController.scala
@@ -28,6 +28,7 @@ import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import queries.RecategorisingQuery
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.SessionData.{dataRemoved, dataUpdated, initialValueOfHasSuppUnit, pageUpdated}
 import views.html.HasSupplementaryUnitView
 
 import javax.inject.Inject
@@ -100,8 +101,13 @@ class HasSupplementaryUnitController @Inject() (
           }
       }
       preparedFormFuture.map { preparedForm =>
+        val formValue            = preparedForm.value.getOrElse(false)
         val onSubmitAction: Call = routes.HasSupplementaryUnitController.onSubmitUpdate(mode, recordId)
         Ok(view(preparedForm, mode, recordId, onSubmitAction))
+          .addingToSession(
+            initialValueOfHasSuppUnit -> formValue.toString
+          )
+          .removingFromSession(dataUpdated, pageUpdated, dataRemoved)
       }
     }
 

--- a/app/controllers/SingleRecordController.scala
+++ b/app/controllers/SingleRecordController.scala
@@ -19,13 +19,15 @@ package controllers
 import connectors.GoodsRecordConnector
 import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierAction, ProfileAuthenticateAction}
 import models.NormalMode
+import models.helper.SupplementaryUnitUpdateJourney
 import pages.{CommodityCodeUpdatePage, CountryOfOriginUpdatePage, GoodsDescriptionUpdatePage, TraderReferenceUpdatePage}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
+import services.DataCleansingService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import utils.SessionData.{dataUpdated, pageUpdated}
-import viewmodels.checkAnswers.{AdviceStatusSummary, CategorySummary, CommodityCodeSummary, CountryOfOriginSummary, GoodsDescriptionSummary, HasSupplementaryUnitSummary, StatusSummary, SupplementaryUnitSummary, TraderReferenceSummary}
+import utils.SessionData._
+import viewmodels.checkAnswers._
 import viewmodels.govuk.summarylist._
 import views.html.SingleRecordView
 
@@ -37,6 +39,7 @@ class SingleRecordController @Inject() (
   sessionRepository: SessionRepository,
   identify: IdentifierAction,
   profileAuth: ProfileAuthenticateAction,
+  dataCleansingService: DataCleansingService,
   getData: DataRetrievalAction,
   requireData: DataRequiredAction,
   val controllerComponents: MessagesControllerComponents,
@@ -98,9 +101,20 @@ class SingleRecordController @Inject() (
           )
         )
         val changesMade           = request.session.get(dataUpdated).contains("true")
+        val pageRemoved           = request.session.get(dataRemoved).contains("true")
         val changedPage           = request.session.get(pageUpdated).getOrElse("")
-
-        Ok(view(recordId, detailsList, categorisationList, supplementaryUnitList, adviceList, changesMade, changedPage))
+        Ok(
+          view(
+            recordId,
+            detailsList,
+            categorisationList,
+            supplementaryUnitList,
+            adviceList,
+            changesMade,
+            changedPage,
+            pageRemoved
+          )
+        )
       }
     }
 }

--- a/app/controllers/SingleRecordController.scala
+++ b/app/controllers/SingleRecordController.scala
@@ -39,7 +39,6 @@ class SingleRecordController @Inject() (
   sessionRepository: SessionRepository,
   identify: IdentifierAction,
   profileAuth: ProfileAuthenticateAction,
-  dataCleansingService: DataCleansingService,
   getData: DataRetrievalAction,
   requireData: DataRequiredAction,
   dataCleansingService: DataCleansingService,
@@ -107,7 +106,6 @@ class SingleRecordController @Inject() (
         //at this point we should delete supplementaryunit journey data as the user might comeback using backlink from suppunit pages & click change link again
         dataCleansingService.deleteMongoData(request.userAnswers.id, SupplementaryUnitUpdateJourney)
 
-        Ok(view(recordId, detailsList, categorisationList, supplementaryUnitList, adviceList, changesMade, changedPage))
         Ok(
           view(
             recordId,
@@ -119,7 +117,7 @@ class SingleRecordController @Inject() (
             changedPage,
             pageRemoved
           )
-        )
+        ).removingFromSession(initialValueOfHasSuppUnit, initialValueOfSuppUnit)
       }
     }
 }

--- a/app/controllers/SupplementaryUnitController.scala
+++ b/app/controllers/SupplementaryUnitController.scala
@@ -30,8 +30,9 @@ import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import queries.{MeasurementQuery, RecordCategorisationsQuery}
 import repositories.SessionRepository
-import services.OttService
+import services.{DataCleansingService, OttService}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.SessionData.{dataRemoved, dataUpdated, initialValueOfSuppUnit, pageUpdated}
 import views.html.SupplementaryUnitView
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -119,8 +120,13 @@ class SupplementaryUnitController @Inject() (
 
       preparedFormFuture
         .map { case (preparedForm, measurementUnit) =>
+          val formValue            = preparedForm.value.getOrElse(false)
           val onSubmitAction: Call = routes.SupplementaryUnitController.onSubmitUpdate(mode, recordId)
           Ok(view(preparedForm, mode, recordId, measurementUnit, onSubmitAction))
+            .addingToSession(
+              initialValueOfSuppUnit -> formValue.toString
+            )
+            .removingFromSession(dataUpdated, pageUpdated, dataRemoved)
         }
         .recover { case ex: Exception =>
           logger.error(s"Error occurred while fetching record for recordId: $recordId", ex)

--- a/app/controllers/TraderReferenceController.scala
+++ b/app/controllers/TraderReferenceController.scala
@@ -84,7 +84,7 @@ class TraderReferenceController @Inject() (
         )
 
       val onSubmitAction = routes.TraderReferenceController.onSubmitUpdate(mode, recordId)
-      Ok(view(preparedForm, onSubmitAction))
+      Ok(view(preparedForm, onSubmitAction)).removingFromSession(dataRemoved, dataUpdated, pageUpdated)
     }
 
   def onSubmitCreate(mode: Mode): Action[AnyContent] =

--- a/app/utils/SessionData.scala
+++ b/app/utils/SessionData.scala
@@ -18,6 +18,7 @@ package utils
 
 case object SessionData {
   val dataUpdated: String                    = "changesMade"
+  val dataRemoved: String                    = "valueRemoved"
   val pageUpdated: String                    = "changedPage"
   val traderReference: String                = "trader reference"
   val goodsDescription: String               = "goods description"
@@ -44,5 +45,7 @@ case object SessionData {
   val longerCommodityCodePage: String        = "longerCommodityCode"
   val namePage: String                       = "name"
   val emailPage: String                      = "email"
+  val initialValueOfHasSuppUnit: String      = "initialValueOfHasSuppUnit"
+  val initialValueOfSuppUnit: String         = "initialValueOfSuppUnit"
 
 }

--- a/app/views/SingleRecordView.scala.html
+++ b/app/views/SingleRecordView.scala.html
@@ -25,11 +25,15 @@
     govukNotificationBanner: GovukNotificationBanner
 )
 
-@(recordId: String, detailsList: SummaryList, categorisationList: SummaryList, supplementaryUnitList: SummaryList, adviceStatusList: SummaryList, changesMade: Boolean, changedPage: String)(implicit request: Request[_], messages: Messages)
+@(recordId: String, detailsList: SummaryList, categorisationList: SummaryList, supplementaryUnitList: SummaryList, adviceStatusList: SummaryList, changesMade: Boolean, changedPage: String,dataRemoved: Boolean)(implicit request: Request[_], messages: Messages)
 
-    @bannerContentForUpdate(page: String) = {
+    @bannerContentForUpdate(page: String,dataRemoved:Boolean) = {
         <h3 class="govuk-notification-banner__heading">
+        @if(dataRemoved) {
+            @messages("sucessBannerRemove.heading", page)
+        } else {
             @messages("sucessBanner.heading", page)
+        }
         </h3>
         <p class="govuk-body">@messages("sucessBanner.p1") <a class="govuk-notification-banner__link" href="#"> @messages("sucessBanner.email")</a> @messages("sucessBanner.p2")</p>
     }
@@ -41,7 +45,7 @@
     @if(changesMade) {
         @govukNotificationBanner(NotificationBanner(
             title = Text(messages("sucessBanner.title")),
-            content = HtmlContent(bannerContentForUpdate(changedPage)),
+            content = HtmlContent(bannerContentForUpdate(changedPage,dataRemoved)),
             bannerType = Some("success"),
             role=Some("alert"))
         )

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -535,6 +535,7 @@ cyaSupplementaryUnit.h2 = Check if the details on this record are correct.
 
 sucessBanner.title = Success
 sucessBanner.heading = You have changed the {0}
+sucessBannerRemove.heading = You have removed the {0}
 sucessBanner.p1 = Contact
 sucessBanner.email = example@department.gov.uk
 sucessBanner.p2 = if you think there’s a problem.

--- a/test/controllers/SingleRecordControllerSpec.scala
+++ b/test/controllers/SingleRecordControllerSpec.scala
@@ -33,7 +33,7 @@ import play.api.test.Helpers._
 import repositories.SessionRepository
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
 import uk.gov.hmrc.http.NotFoundException
-import utils.SessionData.{dataUpdated, pageUpdated}
+import utils.SessionData.{dataRemoved, dataUpdated, pageUpdated}
 import viewmodels.checkAnswers._
 import viewmodels.govuk.summarylist._
 import views.html.SingleRecordView
@@ -134,6 +134,7 @@ class SingleRecordControllerSpec extends SpecBase with MockitoSugar {
         val view                                  = application.injector.instanceOf[SingleRecordView]
         val changesMade                           = request.session.get(dataUpdated).contains("true")
         val changedPage                           = request.session.get(pageUpdated).getOrElse("")
+        val pageRemoved                           = request.session.get(dataRemoved).contains("true")
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(
           testRecordId,
@@ -142,7 +143,8 @@ class SingleRecordControllerSpec extends SpecBase with MockitoSugar {
           supplementaryUnitList,
           adviceList,
           changesMade,
-          changedPage
+          changedPage,
+          pageRemoved
         )(
           request,
           messages(application)


### PR DESCRIPTION
- May look a bit confusing but the Idea is to use session flags to verify if the values have been changed from initial values for showing the banner. 
- We also need to remove the flags from session when the user clicks/navigates from goods record page so the banner can be not shown