### PR TITLE
TGP-1694: Handle "category" on Goods record page

### DIFF
--- a/app/controllers/CyaUpdateRecordController.scala
+++ b/app/controllers/CyaUpdateRecordController.scala
@@ -194,13 +194,11 @@ class CyaUpdateRecordController @Inject() (
             UpdateGoodsRecord(request.eori, recordId, goodsDescription = Some(goodsDescription))
           )
           for {
-            _                        <- goodsRecordConnector.updateGoodsRecord(
-                                          UpdateGoodsRecord(request.eori, recordId, goodsDescription = Some(goodsDescription))
-                                        )
-            updatedAnswersWithChange <-
-              Future.fromTry(request.userAnswers.remove(HasGoodsDescriptionChangePage(recordId)))
-            updatedAnswers           <- Future.fromTry(updatedAnswersWithChange.remove(GoodsDescriptionUpdatePage(recordId)))
-            _                        <- sessionRepository.set(updatedAnswers)
+            _              <- goodsRecordConnector.updateGoodsRecord(
+                                UpdateGoodsRecord(request.eori, recordId, goodsDescription = Some(goodsDescription))
+                              )
+            updatedAnswers <- Future.fromTry(request.userAnswers.remove(GoodsDescriptionUpdatePage(recordId)))
+            _              <- sessionRepository.set(updatedAnswers)
           } yield Redirect(routes.SingleRecordController.onPageLoad(recordId))
         case Left(errors)            =>
           Future.successful(

--- a/app/models/UpdateGoodsRecord.scala
+++ b/app/models/UpdateGoodsRecord.scala
@@ -60,7 +60,7 @@ object UpdateGoodsRecord {
   ): EitherNec[ValidationError, String] =
     (
       Right(recordId),
-      getGoodsDescription(answers, recordId)
+      answers.getPageValue(GoodsDescriptionUpdatePage(recordId))
     ).parMapN((_, value) => value)
 
   def validateCommodityCode(
@@ -108,13 +108,6 @@ object UpdateGoodsRecord {
         Right(commodity)
       case Left(errors)                                                 => Left(errors)
       case _                                                            => Left(NonEmptyChain.one(MismatchedPage(CommodityCodeUpdatePage(recordId))))
-    }
-
-  private def getGoodsDescription(answers: UserAnswers, recordId: String): EitherNec[ValidationError, String] =
-    answers.getPageValue(HasGoodsDescriptionChangePage(recordId)) match {
-      case Right(true)  => answers.getPageValue(GoodsDescriptionUpdatePage(recordId))
-      case Right(false) => Left(NonEmptyChain.one(UnexpectedPage(HasGoodsDescriptionChangePage(recordId))))
-      case Left(errors) => Left(errors)
     }
 
   private def getCountryOfOrigin(answers: UserAnswers, recordId: String): EitherNec[ValidationError, String] =

--- a/app/viewmodels/checkAnswers/GoodsDescriptionSummary.scala
+++ b/app/viewmodels/checkAnswers/GoodsDescriptionSummary.scala
@@ -40,18 +40,13 @@ object GoodsDescriptionSummary {
     }
 
   //TBD - this will be updated to route to the update trader reference page
-  def row(value: String, recordId: String, mode: Mode)(implicit messages: Messages): SummaryListRow = {
-    val changeLink = mode match {
-      case NormalMode => routes.HasGoodsDescriptionChangeController.onPageLoad(mode, recordId).url
-      case CheckMode  => routes.GoodsDescriptionController.onPageLoadUpdate(mode, recordId).url
-    }
+  def row(value: String, recordId: String, mode: Mode)(implicit messages: Messages): SummaryListRow =
     SummaryListRowViewModel(
       key = "goodsDescription.checkYourAnswersLabel",
       value = ValueViewModel(HtmlFormat.escape(value).toString),
       actions = Seq(
-        ActionItemViewModel("site.change", changeLink)
+        ActionItemViewModel("site.change", routes.GoodsDescriptionController.onPageLoadUpdate(mode, recordId).url)
           .withVisuallyHiddenText(messages("goodsDescription.change.hidden"))
       )
     )
-  }
 }

--- a/test/controllers/CyaUpdateRecordControllerSpec.scala
+++ b/test/controllers/CyaUpdateRecordControllerSpec.scala
@@ -325,7 +325,6 @@ class CyaUpdateRecordControllerSpec extends SpecBase with SummaryListFluency wit
       val getUrl          = routes.CyaUpdateRecordController.onPageLoadGoodsDescription(testRecordId).url
       val call            = routes.CyaUpdateRecordController.onSubmitGoodsDescription(testRecordId)
       val postUrl         = routes.CyaUpdateRecordController.onSubmitGoodsDescription(testRecordId).url
-      val warningPage     = HasGoodsDescriptionChangePage(testRecordId)
 
       "for a GET" - {
 
@@ -339,9 +338,6 @@ class CyaUpdateRecordControllerSpec extends SpecBase with SummaryListFluency wit
 
           val userAnswers = emptyUserAnswers
             .set(page, answer)
-            .success
-            .value
-            .set(warningPage, true)
             .success
             .value
 
@@ -412,9 +408,6 @@ class CyaUpdateRecordControllerSpec extends SpecBase with SummaryListFluency wit
               .set(page, answer)
               .success
               .value
-              .set(warningPage, true)
-              .success
-              .value
 
             val mockConnector    = mock[GoodsRecordConnector]
             val mockAuditService = mock[AuditService]
@@ -478,9 +471,6 @@ class CyaUpdateRecordControllerSpec extends SpecBase with SummaryListFluency wit
 
           val userAnswers = emptyUserAnswers
             .set(page, answer)
-            .success
-            .value
-            .set(warningPage, true)
             .success
             .value
 

--- a/test/models/UpdateGoodsRecordSpec.scala
+++ b/test/models/UpdateGoodsRecordSpec.scala
@@ -57,9 +57,6 @@ class UpdateGoodsRecordSpec extends AnyFreeSpec with Matchers with TryValues wit
             .set(GoodsDescriptionUpdatePage(testRecordId), "goods description")
             .success
             .value
-            .set(HasGoodsDescriptionChangePage(testRecordId), true)
-            .success
-            .value
 
         val result = UpdateGoodsRecord.validateGoodsDescription(answers, testRecordId)
 
@@ -149,28 +146,11 @@ class UpdateGoodsRecordSpec extends AnyFreeSpec with Matchers with TryValues wit
       "when goods description is required and is missing" in {
 
         val answers = UserAnswers(userAnswersId)
-          .set(HasGoodsDescriptionChangePage(testRecordId), true)
-          .success
-          .value
 
         val result = UpdateGoodsRecord.validateGoodsDescription(answers, testRecordId)
 
         inside(result) { case Left(errors) =>
           errors.toChain.toList must contain only PageMissing(GoodsDescriptionUpdatePage(testRecordId))
-        }
-      }
-
-      "when goods description warning page is false" in {
-
-        val answers = UserAnswers(userAnswersId)
-          .set(HasGoodsDescriptionChangePage(testRecordId), false)
-          .success
-          .value
-
-        val result = UpdateGoodsRecord.validateGoodsDescription(answers, testRecordId)
-
-        inside(result) { case Left(errors) =>
-          errors.toChain.toList must contain only UnexpectedPage(HasGoodsDescriptionChangePage(testRecordId))
         }
       }
 


### PR DESCRIPTION
[https://jira.tools.tax.service.gov.uk/browse/TGP-1694](url)
Scenario 6 : On goods record page. When record is categorised as 1,2 or standard and we click the change link on goods description row, we skip the warning page and go straight to the goods description input page.
