### PR TITLE
TGP-2087 welsh for advice journey + Error pages

### DIFF
--- a/app/views/JourneyRecoveryContinueView.scala.html
+++ b/app/views/JourneyRecoveryContinueView.scala.html
@@ -29,7 +29,7 @@
 
     <p class="govuk-body">
         @govukButton(
-            ButtonViewModel(messages("site.continue"))
+            ButtonViewModel(messages("site.startAgain"))
                 .asLink(continueUrl)
         )
     </p>

--- a/app/views/JourneyRecoveryStartAgainView.scala.html
+++ b/app/views/JourneyRecoveryStartAgainView.scala.html
@@ -29,7 +29,7 @@
 
     <p class="govuk-body">
         @govukButton(
-            ButtonViewModel(messages("site.startAgain"))
+            ButtonViewModel(messages("site.goToHomePage"))
                 .asLink(routes.IndexController.onPageLoad.url)
         )
     </p>

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -2,8 +2,27 @@ site.yes = Iawn
 site.no = Na
 site.continue = Yn eich blaen
 site.change = Newid
+site.startAgain = Dechrau eto
+site.goToHomePage = Ewch i’r hafan
 
 error.summary.title = Nodwch eich cyfeiriad e-bost
+
+signedOut.title = Rydych bellach wedi allgofnodi
+signedOut.heading = Rydych bellach wedi allgofnodi
+
+unauthorised.title = Mae problem wedi codi
+unauthorised.heading = Mae problem wedi codi
+unauthorised.p1 = Nid yw’r manylion sydd wedi’u mewngofnodi i GOV.UK wedi’u cysylltu â Phroffil Nwyddau Masnachwyr.
+unauthorised.p2.part1 = Os oes gennych Broffil Nwyddau Masnachwyr,
+unauthorised.p2.linkText = dylech allgofnodi
+unauthorised.p2.part2 = a mewngofnodi eto gan ddefnyddio’r manylion cywir.
+
+journeyRecovery.continue.title = Mae rhywbeth wedi mynd o’i le
+journeyRecovery.continue.heading = Mae rhywbeth wedi mynd o’i le
+journeyRecovery.continue.guidance = Mae rhywbeth wedi mynd o’i le – bydd angen i chi ddechrau eto. Nid ydym wedi cadw unrhyw wybodaeth a nodwyd gennych.
+journeyRecovery.startAgain.title = Mae rhywbeth wedi mynd o’i le
+journeyRecovery.startAgain.heading = Mae rhywbeth wedi mynd o’i le
+journeyRecovery.startAgain.guidance = Mae rhywbeth wedi mynd o’i le – ewch i hafan y Proffil Nwyddau Masnachwyr. Nid ydym wedi cadw unrhyw wybodaeth a nodwyd gennych.
 
 profileSetup.title = Sefydlu eich proffil
 profileSetup.h1 = Sefydlu eich proffil
@@ -109,7 +128,6 @@ name.heading = Beth yw eich enw?
 name.hint = Mae angen i ni wybod eich enw er mwyn i ni allu cysylltu â chi.
 name.checkYourAnswersLabel = Enw
 name.error.required = Nodwch eich enw
-    name.error.length = Enter a name with 70 characters or less
 name.change.hidden = Enw
 
 email.title = Beth yw''ch cyfeiriad e-bost?
@@ -117,8 +135,6 @@ email.heading = Beth yw''ch cyfeiriad e-bost?
 email.hint = Byddwn ond yn defnyddio''ch e-bost i gysylltu â chi ynglŷn â''ch cais.
 email.checkYourAnswersLabel = E-bost
 email.error.required = Nodwch eich cyfeiriad e-bost
-    email.error.invalidFormat = Enter a valid email address
-    email.error.length = Email must be 254 characters or less
 email.change.hidden = E-bost
 
 cyaRequestAdvice.title = Gwiriwch eich atebion cyn anfon eich cais am gyngor
@@ -137,5 +153,4 @@ adviceSuccess.p2.4 = nodi bod y cofnod yn anghywir, ac yn esbonio pam
 adviceSuccess.p3 = Gallwch anfon rhagor o wybodaeth am eich nwyddau at CThEF yn [email address] – cofiwch nodi''ch rhif EORI.
 adviceSuccess.p4 = Nid yw e-bost yn ddull diogel o gyfathrebu, felly peidiwch â chynnwys unrhyw fanylion personol yn eich e-bost at CThEF.
 adviceSuccess.p5 = Dylech gael ymateb i''ch cais cyn pen 5 diwrnod gwaith, ond gallai gymryd yn hirach.
-    adviceSuccess.p6.linkText = Go to goods record
 adviceSuccess.p7.linkText = Ewch i''r hafan

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -3,7 +3,7 @@ site.no = Na
 site.continue = Yn eich blaen
 site.change = Newid
 site.startAgain = Dechrau eto
-site.goToHomePage = Ewch i’r hafan
+site.goToHomePage = Ewch i''r hafan
 
 error.summary.title = Nodwch eich cyfeiriad e-bost
 
@@ -12,17 +12,17 @@ signedOut.heading = Rydych bellach wedi allgofnodi
 
 unauthorised.title = Mae problem wedi codi
 unauthorised.heading = Mae problem wedi codi
-unauthorised.p1 = Nid yw’r manylion sydd wedi’u mewngofnodi i GOV.UK wedi’u cysylltu â Phroffil Nwyddau Masnachwyr.
+unauthorised.p1 = Nid yw''r manylion sydd wedi''u mewngofnodi i GOV.UK wedi''u cysylltu â Phroffil Nwyddau Masnachwyr.
 unauthorised.p2.part1 = Os oes gennych Broffil Nwyddau Masnachwyr,
 unauthorised.p2.linkText = dylech allgofnodi
-unauthorised.p2.part2 = a mewngofnodi eto gan ddefnyddio’r manylion cywir.
+unauthorised.p2.part2 = a mewngofnodi eto gan ddefnyddio''r manylion cywir.
 
-journeyRecovery.continue.title = Mae rhywbeth wedi mynd o’i le
-journeyRecovery.continue.heading = Mae rhywbeth wedi mynd o’i le
-journeyRecovery.continue.guidance = Mae rhywbeth wedi mynd o’i le – bydd angen i chi ddechrau eto. Nid ydym wedi cadw unrhyw wybodaeth a nodwyd gennych.
-journeyRecovery.startAgain.title = Mae rhywbeth wedi mynd o’i le
-journeyRecovery.startAgain.heading = Mae rhywbeth wedi mynd o’i le
-journeyRecovery.startAgain.guidance = Mae rhywbeth wedi mynd o’i le – ewch i hafan y Proffil Nwyddau Masnachwyr. Nid ydym wedi cadw unrhyw wybodaeth a nodwyd gennych.
+journeyRecovery.continue.title = Mae rhywbeth wedi mynd o''i le
+journeyRecovery.continue.heading = Mae rhywbeth wedi mynd o''i le
+journeyRecovery.continue.guidance = Mae rhywbeth wedi mynd o''i le – bydd angen i chi ddechrau eto. Nid ydym wedi cadw unrhyw wybodaeth a nodwyd gennych.
+journeyRecovery.startAgain.title = Mae rhywbeth wedi mynd o''i le
+journeyRecovery.startAgain.heading = Mae rhywbeth wedi mynd o''i le
+journeyRecovery.startAgain.guidance = Mae rhywbeth wedi mynd o''i le – ewch i hafan y Proffil Nwyddau Masnachwyr. Nid ydym wedi cadw unrhyw wybodaeth a nodwyd gennych.
 
 profileSetup.title = Sefydlu eich proffil
 profileSetup.h1 = Sefydlu eich proffil

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -3,6 +3,8 @@ site.no = Na
 site.continue = Yn eich blaen
 site.change = Newid
 
+error.summary.title = Nodwch eich cyfeiriad e-bost
+
 profileSetup.title = Sefydlu eich proffil
 profileSetup.h1 = Sefydlu eich proffil
 profileSetup.intro = Rydym am ofyn rhai cwestiynau i chi, yna byddwn yn gofyn am beth o wybodaeth gennych yn dibynnu ar eich atebion.
@@ -88,3 +90,52 @@ ukimsKickOut.h1 = Mae angen i chi wneud cais ar gyfer Cynllun Marchnad Fewnol y 
 ukimsKickOut.p1 = Ni allwch ddefnyddio''r Proffil Nwyddau Masnachwyr (TGP) os nad ydych wedi cofrestru ar gyfer yr UKIMS.
 ukimsKickOut.p2 = Dysgwch sut i
 ukimsKickOut.linkText = gofrestru ar gyfer yr UKIMS (yn agor tab newydd).
+
+adviceStart.title = Gofyn i CThEF am gyngor
+adviceStart.heading = Gofyn i CThEF am gyngor
+adviceStart.p1 = Mae gofyn i CThEF am gyngor yn golygu y cewch wybod os yw CThEF o''r farn bod y cod nwyddau yn cyd-fynd â''r wybodaeth sydd yn eich cofnod nwyddau.
+adviceStart.warningText = Nid yw''r cyngor hwn yn gyfreithiol rwymol.
+adviceStart.p2 = Os ydych am gael penderfyniad sy''n gyfreithiol rwymol,
+adviceStart.p2.linkText = gwnewch gais am benderfyniad ynghylch gwybodaeth am Dariff sy''n Rhwymo.
+adviceStart.subheading1 = Yr hyn y mae ei angen ar CThEF
+adviceStart.p3 = Byddwn yn gofyn am eich enw a''ch cyfeiriad e-bost. Bydd gweithiwr achos CThEF yn edrych ar y cofnod nwyddau dan sylw.
+adviceStart.subheading2 = Yr hyn sy''n digwydd tra bod CThEF yn edrych ar eich cofnod
+adviceStart.p4 = Ni fydd modd i chi wneud unrhyw newidiadau i''ch cofnod tra bod CThEF yn ei adolygu. Sylwer – efallai na fydd cyfathrebu drwy e-bost bob amser yn ddiogel, gan ei bod hi''n bosib y gall e-byst gael eu darllen neu eu newid gan rywun arall.
+adviceStart.p5 = Os ydych am anfon rhagor o wybodaeth am y cofnod nwyddau at weithiwr achos CThEF, gallwch wneud hyn drwy anfon e-bost.
+adviceStart.p6 = Dylech gael ymateb i''ch cais cyn pen 5 diwrnod gwaith, ond gallai gymryd yn hirach.
+
+name.title = Beth yw eich enw?
+name.heading = Beth yw eich enw?
+name.hint = Mae angen i ni wybod eich enw er mwyn i ni allu cysylltu â chi.
+name.checkYourAnswersLabel = Enw
+name.error.required = Nodwch eich enw
+    name.error.length = Enter a name with 70 characters or less
+name.change.hidden = Enw
+
+email.title = Beth yw''ch cyfeiriad e-bost?
+email.heading = Beth yw''ch cyfeiriad e-bost?
+email.hint = Byddwn ond yn defnyddio''ch e-bost i gysylltu â chi ynglŷn â''ch cais.
+email.checkYourAnswersLabel = E-bost
+email.error.required = Nodwch eich cyfeiriad e-bost
+    email.error.invalidFormat = Enter a valid email address
+    email.error.length = Email must be 254 characters or less
+email.change.hidden = E-bost
+
+cyaRequestAdvice.title = Gwiriwch eich atebion cyn anfon eich cais am gyngor
+cyaRequestAdvice.heading = Gwiriwch eich atebion cyn anfon eich cais am gyngor
+cyaRequestAdvice.subheading = Manylion cyswllt
+
+adviceSuccess.title = Cais am gyngor wedi''i gwblhau
+adviceSuccess.h1 = Cais am gyngor wedi''i gwblhau
+adviceSuccess.h2 = Yr hyn sy''n digwydd nesaf
+adviceSuccess.p1 = Bydd CThEF yn cysylltu â chi i roi gwybod am ei benderfyniad.
+adviceSuccess.p2 = Gallai''r penderfyniad fod yn un o''r canlynol:
+adviceSuccess.p2.1 = cytuno bod y cod nwyddau yn gywir
+adviceSuccess.p2.2 = gofyn am ragor o wybodaeth am y nwyddau
+adviceSuccess.p2.3 = cynnig newid i''r cod nwyddau neu i ddisgrifiad y nwyddau
+adviceSuccess.p2.4 = nodi bod y cofnod yn anghywir, ac yn esbonio pam
+adviceSuccess.p3 = Gallwch anfon rhagor o wybodaeth am eich nwyddau at CThEF yn [email address] – cofiwch nodi''ch rhif EORI.
+adviceSuccess.p4 = Nid yw e-bost yn ddull diogel o gyfathrebu, felly peidiwch â chynnwys unrhyw fanylion personol yn eich e-bost at CThEF.
+adviceSuccess.p5 = Dylech gael ymateb i''ch cais cyn pen 5 diwrnod gwaith, ond gallai gymryd yn hirach.
+    adviceSuccess.p6.linkText = Go to goods record
+adviceSuccess.p7.linkText = Ewch i''r hafan

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -13,6 +13,7 @@ site.signIn = Sign in
 site.govuk = GOV.UK
 site.or = or
 site.search = Search
+site.goToHomePage = Go to homepage
 
 date.day = Day
 date.month = Month
@@ -60,12 +61,12 @@ cyaCategorisation.categorisationQuestion = Do you meet any of the following cond
 cyaCategorisation.supplementaryUnitHeader = Supplementary Unit
 cyaCategorisation.longerCommodityCode = Longer commodity code
 
-journeyRecovery.continue.title = Sorry, there is a problem with the service
-journeyRecovery.continue.heading = Sorry, there is a problem with the service
-journeyRecovery.continue.guidance = [Add content to explain how to proceed.]
-journeyRecovery.startAgain.title = Sorry, there is a problem with the service
-journeyRecovery.startAgain.heading = Sorry, there is a problem with the service
-journeyRecovery.startAgain.guidance = [Add content to explain why the user needs to start again.]
+journeyRecovery.continue.title = Something has gone wrong
+journeyRecovery.continue.heading = Something has gone wrong
+journeyRecovery.continue.guidance = Something has gone wrong and you'll need to start again. We have not saved any information you've entered.
+journeyRecovery.startAgain.title = Something has gone wrong
+journeyRecovery.startAgain.heading = Something has gone wrong
+journeyRecovery.startAgain.guidance = Something has gone wrong and you'll need to go to the Trader Goods Profile homepage. We have not saved any information you've entered.
 
 signedOut.title = You have now signed out
 signedOut.heading = You have now signed out


### PR DESCRIPTION
Journey recovery has been done as best as possible, but it didn't have english yet, so I've put the english and welsh in but it maybe that needs it's own ticket. It seems confusing but it looks like we used the start again page as a "go to homepage" thing and we used the continue page as the "start again" page.

These do not have translations and so I can't add them: 
adviceSuccess.p6.linkText = Go to goods record
name.error.length = Enter a name with 70 characters or less
email.error.invalidFormat = Enter a valid email address
email.error.length = Email must be 254 characters or less