### PR TITLE
Fix for random build failure

### DIFF
--- a/test/forms/behaviours/StringFieldBehaviours.scala
+++ b/test/forms/behaviours/StringFieldBehaviours.scala
@@ -24,7 +24,7 @@ trait StringFieldBehaviours extends FieldBehaviours {
   def fieldWithMaxLength(form: Form[_], fieldName: String, maxLength: Int, lengthError: FormError): Unit =
     s"not bind strings longer than $maxLength characters" in {
 
-      forAll(stringsLongerThan(maxLength) -> "longString") { string =>
+      forAll(stringsWithMaxLength(maxLength) -> "longString") { string =>
         val result = form.bind(Map(fieldName -> string)).apply(fieldName)
         result.errors must contain only lengthError
       }


### PR DESCRIPTION
We often experience random build failures in the pipeline due to the string generation method, which seems to have been incorrect, so it has been updated.