### PR TITLE
TGP-2248: Added a hidden label for screen readers.

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -60,9 +60,6 @@ if (typeof accessibleAutocomplete != 'undefined' && document.querySelector('.aut
     selectEl.parentNode.insertBefore(label, selectEl);
   }
 
-
-
-
   // =====================================================
   // Polyfill autocomplete once loaded
   // =====================================================

--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -38,6 +38,11 @@ function upTo(el, tagName) {
 if (typeof accessibleAutocomplete != 'undefined' && document.querySelector('.autocomplete') != null) {
   // load autocomplete
   var selectEl = document.querySelector('.autocomplete');
+
+  // Clone a hidden copy of the label to insert later
+  let label = document.querySelector("label[for=" + selectEl.id + "]").cloneNode(true);
+  label.setAttribute("style", "display: none;");
+
   if (selectEl && selectEl.style.display !== "none") {
     accessibleAutocomplete.enhanceSelectElement({
       autoselect: true,
@@ -47,7 +52,16 @@ if (typeof accessibleAutocomplete != 'undefined' && document.querySelector('.aut
       selectElement: selectEl,
       showAllValues: true
     });
+
+    // Overwrite 'for' attribute of the hidden label after autocomplete changes are applied
+    label.setAttribute("for", document.querySelector('.autocomplete').id);
+
+    // Insert the hidden label immediately before the selectEl
+    selectEl.parentNode.insertBefore(label, selectEl);
   }
+
+
+
 
   // =====================================================
   // Polyfill autocomplete once loaded


### PR DESCRIPTION
The issue was that the select element that the autocomplete JS thing hides needed a label. Since it's only hidden, not deleted, it does need a label. It can't be deleted either, as the accessible autocomplete relies on it.

I added a hidden label, and used a screen reader to check it all behaves the same :)