### PR TITLE
TGP-2043: Fix for back button behaviour on recategorisation 

### DIFF
--- a/app/controllers/AssessmentController.scala
+++ b/app/controllers/AssessmentController.scala
@@ -18,7 +18,7 @@ package controllers
 
 import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierAction}
 import forms.AssessmentFormProvider
-import models.Mode
+import models.{Mode, ReassessmentAnswer}
 import navigation.Navigator
 import pages.{AssessmentPage, ReassessmentPage}
 import play.api.i18n.MessagesApi
@@ -74,7 +74,7 @@ class AssessmentController @Inject() (
             val form      = formProvider(listItems.size)
 
             val preparedForm = request.userAnswers.get(ReassessmentPage(recordId, index)) match {
-              case Some(value) => form.fill(value)
+              case Some(value) => form.fill(value.answer)
               case None        => form
             }
 
@@ -154,7 +154,9 @@ class AssessmentController @Inject() (
                   ),
                 value =>
                   for {
-                    updatedAnswers <- Future.fromTry(request.userAnswers.set(ReassessmentPage(recordId, index), value))
+                    updatedAnswers <-
+                      Future
+                        .fromTry(request.userAnswers.set(ReassessmentPage(recordId, index), ReassessmentAnswer(value)))
                     _              <- sessionRepository.set(updatedAnswers)
                   } yield Redirect(navigator.nextPage(ReassessmentPage(recordId, index), mode, updatedAnswers))
               )

--- a/app/controllers/CategorisationPreparationController.scala
+++ b/app/controllers/CategorisationPreparationController.scala
@@ -19,7 +19,7 @@ package controllers
 import connectors.GoodsRecordConnector
 import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierAction, ProfileAuthenticateAction}
 import models.ott.CategorisationInfo
-import models.{CategoryRecord, Commodity, Mode, NormalMode, UserAnswers}
+import models.{CategoryRecord, Mode, NormalMode, UserAnswers}
 import navigation.Navigator
 import org.apache.pekko.Done
 import pages.{CategorisationPreparationPage, HasSupplementaryUnitPage, RecategorisationPreparationPage}
@@ -29,7 +29,6 @@ import queries.{CategorisationDetailsQuery, LongerCategorisationDetailsQuery, Lo
 import repositories.SessionRepository
 import services.CategorisationService
 import uk.gov.hmrc.http.HeaderCarrier
-import utils.Constants.minimumLengthOfCommodityCode
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/models/ReassessmentAnswer.scala
+++ b/app/models/ReassessmentAnswer.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{Format, Json}
+
+case class ReassessmentAnswer(
+  answer: AssessmentAnswer,
+  isAnswerCopiedFromPreviousAssessment: Boolean = false
+)
+
+object ReassessmentAnswer {
+  implicit val reads: Format[ReassessmentAnswer] = Json.format[ReassessmentAnswer]
+}

--- a/app/models/ott/CategorisationInfo.scala
+++ b/app/models/ott/CategorisationInfo.scala
@@ -58,7 +58,7 @@ final case class CategorisationInfo(
       AnsweredQuestions(
         assessment._2,
         assessment._1,
-        userAnswers.get(ReassessmentPage(recordId, assessment._2)),
+        userAnswers.get(ReassessmentPage(recordId, assessment._2)).map(_.answer),
         reassessmentQuestion = true
       )
     )

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -278,7 +278,7 @@ class Navigator @Inject() (categorisationService: CategorisationService) {
     answers.get(LongerCategorisationDetailsQuery(recordId)) match {
       case Some(catInfo) if catInfo.categoryAssessmentsThatNeedAnswers.nonEmpty =>
         val firstAnswer = answers.get(ReassessmentPage(recordId, firstAssessmentIndex))
-        if (answerIsEmpty(firstAnswer)) {
+        if (reassessmentAnswerIsEmpty(firstAnswer) || !firstAnswer.get.isAnswerCopiedFromPreviousAssessment) {
           routes.AssessmentController.onPageLoadReassessment(NormalMode, recordId, firstAssessmentIndex)
         } else {
           navigateFromReassessment(ReassessmentPage(recordId, firstAssessmentIndex))(answers)
@@ -304,8 +304,11 @@ class Navigator @Inject() (categorisationService: CategorisationService) {
         assessmentQuestion <- categorisationInfo.getAssessmentFromIndex(assessmentPage.index)
         nextAnswer          = answers.get(ReassessmentPage(recordId, nextIndex))
         assessmentAnswer   <- answers.get(assessmentPage)
-      } yield assessmentAnswer match {
-        case AssessmentAnswer.Exemption if nextIndex < assessmentCount && answerIsEmpty(nextAnswer)              =>
+      } yield assessmentAnswer.answer match {
+        case AssessmentAnswer.Exemption
+            if nextIndex < assessmentCount && (reassessmentAnswerIsEmpty(nextAnswer) || !nextAnswer.exists(
+              _.isAnswerCopiedFromPreviousAssessment
+            )) =>
           routes.AssessmentController.onPageLoadReassessment(NormalMode, recordId, nextIndex)
         case AssessmentAnswer.Exemption if nextIndex < assessmentCount                                           =>
           navigateFromReassessment(ReassessmentPage(recordId, nextIndex))(answers)
@@ -495,7 +498,7 @@ class Navigator @Inject() (categorisationService: CategorisationService) {
     answers.get(LongerCategorisationDetailsQuery(recordId)) match {
       case Some(catInfo) if catInfo.categoryAssessmentsThatNeedAnswers.nonEmpty =>
         val firstAnswer = answers.get(ReassessmentPage(recordId, firstAssessmentIndex))
-        if (answerIsEmpty(firstAnswer)) {
+        if (reassessmentAnswerIsEmpty(firstAnswer) || !firstAnswer.get.isAnswerCopiedFromPreviousAssessment) {
           routes.AssessmentController.onPageLoadReassessment(CheckMode, recordId, firstAssessmentIndex)
         } else {
           navigateFromReassessmentCheck(ReassessmentPage(recordId, firstAssessmentIndex))(answers)
@@ -520,15 +523,18 @@ class Navigator @Inject() (categorisationService: CategorisationService) {
       assessmentQuestion <- categorisationInfo.getAssessmentFromIndex(assessmentPage.index)
       assessmentAnswer   <- answers.get(assessmentPage)
       nextAnswer          = answers.get(ReassessmentPage(recordId, nextIndex))
-    } yield assessmentAnswer match {
-      case AssessmentAnswer.Exemption if nextIndex < assessmentCount && answerIsEmpty(nextAnswer) =>
+    } yield assessmentAnswer.answer match {
+      case AssessmentAnswer.Exemption
+          if nextIndex < assessmentCount && (reassessmentAnswerIsEmpty(nextAnswer) || !nextAnswer.exists(
+            _.isAnswerCopiedFromPreviousAssessment
+          )) =>
         routes.AssessmentController.onPageLoadReassessment(CheckMode, recordId, nextIndex)
-      case AssessmentAnswer.Exemption if nextIndex < assessmentCount                              =>
+      case AssessmentAnswer.Exemption if nextIndex < assessmentCount =>
         navigateFromReassessmentCheck(ReassessmentPage(recordId, nextIndex))(answers)
       case AssessmentAnswer.NoExemption
           if shouldGoToSupplementaryUnitCheck(answers, categorisationInfo, assessmentQuestion, recordId) =>
         routes.HasSupplementaryUnitController.onPageLoad(CheckMode, recordId)
-      case _                                                                                      =>
+      case _                                                         =>
         routes.CyaCategorisationController.onPageLoad(recordId)
     }
   } getOrElse routes.JourneyRecoveryController.onPageLoad()

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -518,9 +518,9 @@ class Navigator @Inject() (categorisationService: CategorisationService) {
       nextAnswer          = answers.get(ReassessmentPage(recordId, nextIndex))
     } yield assessmentAnswer.answer match {
       case AssessmentAnswer.Exemption
-          if nextIndex < assessmentCount && reassessmentAnswerIsEmpty(nextAnswer) || !nextAnswer.exists(
+          if nextIndex < assessmentCount && (reassessmentAnswerIsEmpty(nextAnswer) || !nextAnswer.exists(
             _.isAnswerCopiedFromPreviousAssessment
-          ) =>
+          )) =>
         routes.AssessmentController.onPageLoadReassessment(CheckMode, recordId, nextIndex)
       case AssessmentAnswer.Exemption if nextIndex < assessmentCount =>
         navigateFromReassessmentCheck(ReassessmentPage(recordId, nextIndex))(answers)

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -268,7 +268,7 @@ class Navigator @Inject() (categorisationService: CategorisationService) {
     answers.get(LongerCategorisationDetailsQuery(recordId)) match {
       case Some(catInfo) if catInfo.categoryAssessmentsThatNeedAnswers.nonEmpty =>
         val firstAnswer = answers.get(ReassessmentPage(recordId, firstAssessmentIndex))
-        if (answerIsEmpty(firstAnswer)) {
+        if (reassessmentAnswerIsEmpty(firstAnswer) || !firstAnswer.get.isAnswerCopiedFromPreviousAssessment) {
           routes.AssessmentController.onPageLoadReassessment(NormalMode, recordId, firstAssessmentIndex)
         } else {
           navigateFromReassessment(ReassessmentPage(recordId, firstAssessmentIndex))(answers)
@@ -294,8 +294,11 @@ class Navigator @Inject() (categorisationService: CategorisationService) {
         assessmentQuestion <- categorisationInfo.getAssessmentFromIndex(assessmentPage.index)
         nextAnswer          = answers.get(ReassessmentPage(recordId, nextIndex))
         assessmentAnswer   <- answers.get(assessmentPage)
-      } yield assessmentAnswer match {
-        case AssessmentAnswer.Exemption if nextIndex < assessmentCount && answerIsEmpty(nextAnswer)              =>
+      } yield assessmentAnswer.answer match {
+        case AssessmentAnswer.Exemption
+            if nextIndex < assessmentCount && (reassessmentAnswerIsEmpty(nextAnswer) || !nextAnswer.exists(
+              _.isAnswerCopiedFromPreviousAssessment
+            )) =>
           routes.AssessmentController.onPageLoadReassessment(NormalMode, recordId, nextIndex)
         case AssessmentAnswer.Exemption if nextIndex < assessmentCount                                           =>
           navigateFromReassessment(ReassessmentPage(recordId, nextIndex))(answers)
@@ -485,7 +488,7 @@ class Navigator @Inject() (categorisationService: CategorisationService) {
     answers.get(LongerCategorisationDetailsQuery(recordId)) match {
       case Some(catInfo) if catInfo.categoryAssessmentsThatNeedAnswers.nonEmpty =>
         val firstAnswer = answers.get(ReassessmentPage(recordId, firstAssessmentIndex))
-        if (answerIsEmpty(firstAnswer)) {
+        if (reassessmentAnswerIsEmpty(firstAnswer)) {
           routes.AssessmentController.onPageLoadReassessment(CheckMode, recordId, firstAssessmentIndex)
         } else {
           navigateFromReassessmentCheck(ReassessmentPage(recordId, firstAssessmentIndex))(answers)
@@ -510,15 +513,15 @@ class Navigator @Inject() (categorisationService: CategorisationService) {
       assessmentQuestion <- categorisationInfo.getAssessmentFromIndex(assessmentPage.index)
       assessmentAnswer   <- answers.get(assessmentPage)
       nextAnswer          = answers.get(ReassessmentPage(recordId, nextIndex))
-    } yield assessmentAnswer match {
-      case AssessmentAnswer.Exemption if nextIndex < assessmentCount && answerIsEmpty(nextAnswer) =>
+    } yield assessmentAnswer.answer match {
+      case AssessmentAnswer.Exemption if nextIndex < assessmentCount && reassessmentAnswerIsEmpty(nextAnswer) =>
         routes.AssessmentController.onPageLoadReassessment(CheckMode, recordId, nextIndex)
-      case AssessmentAnswer.Exemption if nextIndex < assessmentCount                              =>
+      case AssessmentAnswer.Exemption if nextIndex < assessmentCount                                          =>
         navigateFromReassessmentCheck(ReassessmentPage(recordId, nextIndex))(answers)
       case AssessmentAnswer.NoExemption
           if shouldGoToSupplementaryUnitCheck(answers, categorisationInfo, assessmentQuestion, recordId) =>
         routes.HasSupplementaryUnitController.onPageLoad(CheckMode, recordId)
-      case _                                                                                      =>
+      case _                                                                                                  =>
         routes.CyaCategorisationController.onPageLoad(recordId)
     }
   } getOrElse routes.JourneyRecoveryController.onPageLoad()
@@ -598,5 +601,8 @@ class Navigator @Inject() (categorisationService: CategorisationService) {
 
   private def answerIsEmpty(nextAnswer: Option[AssessmentAnswer]) =
     nextAnswer.isEmpty || nextAnswer.contains(AssessmentAnswer.NotAnsweredYet)
+
+  private def reassessmentAnswerIsEmpty(nextAnswer: Option[ReassessmentAnswer]) =
+    nextAnswer.isEmpty || nextAnswer.exists(x => x.answer == AssessmentAnswer.NotAnsweredYet)
 
 }

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -609,6 +609,6 @@ class Navigator @Inject() (categorisationService: CategorisationService) {
     nextAnswer.isEmpty || nextAnswer.contains(AssessmentAnswer.NotAnsweredYet)
 
   private def reassessmentAnswerIsEmpty(nextAnswer: Option[ReassessmentAnswer]) =
-    nextAnswer.isEmpty || nextAnswer.exists(x => x.answer == AssessmentAnswer.NotAnsweredYet)
+    nextAnswer.isEmpty || nextAnswer.exists(reassessment => reassessment.answer == AssessmentAnswer.NotAnsweredYet)
 
 }

--- a/app/pages/LongerCommodityCodePage.scala
+++ b/app/pages/LongerCommodityCodePage.scala
@@ -39,7 +39,7 @@ case class LongerCommodityCodePage(recordId: String) extends QuestionPage[String
       shortCatInfo  <- updatedUserAnswers.get(CategorisationDetailsQuery(recordId))
     } yield
       if (s"${shortCatInfo.commodityCode}$longerComCode" == commodity.commodityCode) {
-        Success(updatedUserAnswers)
+        super.cleanup(value, updatedUserAnswers, originalUserAnswers)
       } else {
         updatedUserAnswers.remove(HasCorrectGoodsLongerCommodityCodePage(recordId))
       }

--- a/app/pages/LongerCommodityCodePage.scala
+++ b/app/pages/LongerCommodityCodePage.scala
@@ -20,7 +20,7 @@ import models.UserAnswers
 import play.api.libs.json.JsPath
 import queries.{CategorisationDetailsQuery, LongerCommodityQuery}
 
-import scala.util.{Success, Try}
+import scala.util.Try
 
 case class LongerCommodityCodePage(recordId: String) extends QuestionPage[String] {
 

--- a/app/pages/ReassessmentPage.scala
+++ b/app/pages/ReassessmentPage.scala
@@ -33,7 +33,7 @@ case class ReassessmentPage(
     updatedUserAnswers: UserAnswers,
     originalUserAnswers: UserAnswers
   ): Try[UserAnswers] =
-    if (value.exists(x => x.answer == AssessmentAnswer.NoExemption)) {
+    if (value.exists(reassessment => reassessment.answer == AssessmentAnswer.NoExemption)) {
       (for {
         categorisationInfo <- updatedUserAnswers.get(LongerCategorisationDetailsQuery(recordId))
         count               = categorisationInfo.categoryAssessmentsThatNeedAnswers.size

--- a/app/pages/ReassessmentPage.scala
+++ b/app/pages/ReassessmentPage.scala
@@ -16,7 +16,7 @@
 
 package pages
 
-import models.{AssessmentAnswer, UserAnswers}
+import models.{AssessmentAnswer, ReassessmentAnswer, UserAnswers}
 import play.api.libs.json.JsPath
 import queries.LongerCategorisationDetailsQuery
 
@@ -25,15 +25,15 @@ import scala.util.{Failure, Success, Try}
 case class ReassessmentPage(
   recordId: String,
   index: Int
-) extends QuestionPage[AssessmentAnswer] {
+) extends QuestionPage[ReassessmentAnswer] {
   override def path: JsPath = JsPath \ "reassessments" \ recordId \ index
 
   override def cleanup(
-    value: Option[AssessmentAnswer],
+    value: Option[ReassessmentAnswer],
     updatedUserAnswers: UserAnswers,
     originalUserAnswers: UserAnswers
   ): Try[UserAnswers] =
-    if (value.contains(AssessmentAnswer.NoExemption)) {
+    if (value.exists(x => x.answer == AssessmentAnswer.NoExemption)) {
       (for {
         categorisationInfo <- updatedUserAnswers.get(LongerCategorisationDetailsQuery(recordId))
         count               = categorisationInfo.categoryAssessmentsThatNeedAnswers.size

--- a/app/services/CategorisationService.scala
+++ b/app/services/CategorisationService.scala
@@ -153,7 +153,9 @@ class CategorisationService @Inject() (
     // This is needed as stored as Json array
     val uaWithPlaceholders = newAssessments.zipWithIndex.foldLeft[Try[UserAnswers]](Success(userAnswers)) {
       (currentAnswers, newAssessment) =>
-        currentAnswers.flatMap(_.set(ReassessmentPage(recordId, newAssessment._2), AssessmentAnswer.NotAnsweredYet))
+        currentAnswers.flatMap(
+          _.set(ReassessmentPage(recordId, newAssessment._2), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
+        )
     }
 
     val answersToKeepSortedByNewIndex = listOfAnswersToKeep.toSeq.sortBy(_._1)
@@ -164,7 +166,13 @@ class CategorisationService @Inject() (
         val assessmentIndex     = answerToKeep._1
         val assessmentAnswerOpt = answerToKeep._2
         assessmentAnswerOpt match {
-          case Some(answer) => currentAnswers.flatMap(_.set(ReassessmentPage(recordId, assessmentIndex), answer))
+          case Some(answer) =>
+            currentAnswers.flatMap(
+              _.set(
+                ReassessmentPage(recordId, assessmentIndex),
+                ReassessmentAnswer(answer, isAnswerCopiedFromPreviousAssessment = true)
+              )
+            )
           case None         => currentAnswers
         }
     }

--- a/app/viewmodels/checkAnswers/AssessmentsSummary.scala
+++ b/app/viewmodels/checkAnswers/AssessmentsSummary.scala
@@ -33,53 +33,45 @@ object AssessmentsSummary {
     assessment: CategoryAssessment,
     indexOfThisAssessment: Int,
     isReassessmentAnswer: Boolean
-  )(implicit messages: Messages): Option[SummaryListRow] =
+  )(implicit messages: Messages): Option[SummaryListRow] = {
+
+    def createSummaryListRowHelper(answer: AssessmentAnswer, changeLink: String): SummaryListRow = {
+      val codes        = assessment.exemptions.map(_.code)
+      val descriptions = assessment.exemptions.map(_.description)
+
+      SummaryListRowViewModel(
+        key = KeyViewModel(AssessmentCyaKey(codes, descriptions, (indexOfThisAssessment + 1).toString).content)
+          .withCssClass("govuk-!-width-one-half"),
+        value = ValueViewModel(
+          if (answer == AssessmentAnswer.Exemption) {
+            messages("site.yes")
+          } else {
+            messages("site.no")
+          }
+        ),
+        actions = Seq(
+          ActionItemViewModel(
+            "site.change",
+            changeLink
+          ).withVisuallyHiddenText(messages("assessment.change.hidden", indexOfThisAssessment + 1))
+        )
+      )
+    }
+
     if (isReassessmentAnswer) {
       answers.get(ReassessmentPage(recordId, indexOfThisAssessment)).map { answer =>
-        val codes        = assessment.exemptions.map(_.code)
-        val descriptions = assessment.exemptions.map(_.description)
-
-        SummaryListRowViewModel(
-          key = KeyViewModel(AssessmentCyaKey(codes, descriptions, (indexOfThisAssessment + 1).toString).content)
-            .withCssClass("govuk-!-width-one-half"),
-          value = ValueViewModel(
-            if (answer.answer == AssessmentAnswer.Exemption) {
-              messages("site.yes")
-            } else {
-              messages("site.no")
-            }
-          ),
-          actions = Seq(
-            ActionItemViewModel(
-              "site.change",
-              routes.AssessmentController.onPageLoadReassessment(CheckMode, recordId, indexOfThisAssessment).url
-            ).withVisuallyHiddenText(messages("assessment.change.hidden", indexOfThisAssessment + 1))
-          )
+        createSummaryListRowHelper(
+          answer.answer,
+          routes.AssessmentController.onPageLoadReassessment(CheckMode, recordId, indexOfThisAssessment).url
         )
       }
     } else {
       answers.get(AssessmentPage(recordId, indexOfThisAssessment)).map { answer =>
-        val codes        = assessment.exemptions.map(_.code)
-        val descriptions = assessment.exemptions.map(_.description)
-
-        SummaryListRowViewModel(
-          key = KeyViewModel(AssessmentCyaKey(codes, descriptions, (indexOfThisAssessment + 1).toString).content)
-            .withCssClass("govuk-!-width-one-half"),
-          value = ValueViewModel(
-            if (answer == AssessmentAnswer.Exemption) {
-              messages("site.yes")
-            } else {
-              messages("site.no")
-            }
-          ),
-          actions = Seq(
-            ActionItemViewModel(
-              "site.change",
-              routes.AssessmentController.onPageLoad(CheckMode, recordId, indexOfThisAssessment).url
-            ).withVisuallyHiddenText(messages("assessment.change.hidden", indexOfThisAssessment + 1))
-          )
+        createSummaryListRowHelper(
+          answer,
+          routes.AssessmentController.onPageLoad(CheckMode, recordId, indexOfThisAssessment).url
         )
       }
     }
-
+  }
 }

--- a/app/viewmodels/checkAnswers/AssessmentsSummary.scala
+++ b/app/viewmodels/checkAnswers/AssessmentsSummary.scala
@@ -33,42 +33,53 @@ object AssessmentsSummary {
     assessment: CategoryAssessment,
     indexOfThisAssessment: Int,
     isReassessmentAnswer: Boolean
-  )(implicit messages: Messages): Option[SummaryListRow] = {
+  )(implicit messages: Messages): Option[SummaryListRow] =
+    if (isReassessmentAnswer) {
+      answers.get(ReassessmentPage(recordId, indexOfThisAssessment)).map { answer =>
+        val codes        = assessment.exemptions.map(_.code)
+        val descriptions = assessment.exemptions.map(_.description)
 
-    val (pageToUse, changeLink) = if (isReassessmentAnswer) {
-      (
-        ReassessmentPage(recordId, indexOfThisAssessment),
-        routes.AssessmentController.onPageLoadReassessment(CheckMode, recordId, indexOfThisAssessment).url
-      )
-    } else {
-      (
-        AssessmentPage(recordId, indexOfThisAssessment),
-        routes.AssessmentController.onPageLoad(CheckMode, recordId, indexOfThisAssessment).url
-      )
-    }
-
-    answers.get(pageToUse).map { answer =>
-      val codes        = assessment.exemptions.map(_.code)
-      val descriptions = assessment.exemptions.map(_.description)
-
-      SummaryListRowViewModel(
-        key = KeyViewModel(AssessmentCyaKey(codes, descriptions, (indexOfThisAssessment + 1).toString).content)
-          .withCssClass("govuk-!-width-one-half"),
-        value = ValueViewModel(
-          if (answer == AssessmentAnswer.Exemption) {
-            messages("site.yes")
-          } else {
-            messages("site.no")
-          }
-        ),
-        actions = Seq(
-          ActionItemViewModel(
-            "site.change",
-            changeLink
-          ).withVisuallyHiddenText(messages("assessment.change.hidden", indexOfThisAssessment + 1))
+        SummaryListRowViewModel(
+          key = KeyViewModel(AssessmentCyaKey(codes, descriptions, (indexOfThisAssessment + 1).toString).content)
+            .withCssClass("govuk-!-width-one-half"),
+          value = ValueViewModel(
+            if (answer.answer == AssessmentAnswer.Exemption) {
+              messages("site.yes")
+            } else {
+              messages("site.no")
+            }
+          ),
+          actions = Seq(
+            ActionItemViewModel(
+              "site.change",
+              routes.AssessmentController.onPageLoadReassessment(CheckMode, recordId, indexOfThisAssessment).url
+            ).withVisuallyHiddenText(messages("assessment.change.hidden", indexOfThisAssessment + 1))
+          )
         )
-      )
+      }
+    } else {
+      answers.get(AssessmentPage(recordId, indexOfThisAssessment)).map { answer =>
+        val codes        = assessment.exemptions.map(_.code)
+        val descriptions = assessment.exemptions.map(_.description)
+
+        SummaryListRowViewModel(
+          key = KeyViewModel(AssessmentCyaKey(codes, descriptions, (indexOfThisAssessment + 1).toString).content)
+            .withCssClass("govuk-!-width-one-half"),
+          value = ValueViewModel(
+            if (answer == AssessmentAnswer.Exemption) {
+              messages("site.yes")
+            } else {
+              messages("site.no")
+            }
+          ),
+          actions = Seq(
+            ActionItemViewModel(
+              "site.change",
+              routes.AssessmentController.onPageLoad(CheckMode, recordId, indexOfThisAssessment).url
+            ).withVisuallyHiddenText(messages("assessment.change.hidden", indexOfThisAssessment + 1))
+          )
+        )
+      }
     }
-  }
 
 }

--- a/test/controllers/AssessmentControllerSpec.scala
+++ b/test/controllers/AssessmentControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import base.TestConstants.testRecordId
 import forms.AssessmentFormProvider
 import models.ott.{CategorisationInfo, CategoryAssessment}
-import models.{AssessmentAnswer, NormalMode}
+import models.{AssessmentAnswer, NormalMode, ReassessmentAnswer}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{verify, when}
@@ -364,7 +364,7 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar with BeforeAnd
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.NoExemption)
+                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.NoExemption))
                 .success
                 .value
 
@@ -468,7 +468,10 @@ class AssessmentControllerSpec extends SpecBase with MockitoSugar with BeforeAnd
             val result = route(application, request).value
 
             val expectedAnswers =
-              answers.set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.NoExemption).success.value
+              answers
+                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.NoExemption))
+                .success
+                .value
 
             status(result) mustEqual SEE_OTHER
             redirectLocation(result).value mustEqual onwardRoute.url

--- a/test/controllers/CategorisationPreparationControllerSpec.scala
+++ b/test/controllers/CategorisationPreparationControllerSpec.scala
@@ -748,61 +748,63 @@ class CategorisationPreparationControllerSpec extends SpecBase with BeforeAndAft
 
       }
 
-      "and save the category information without copying answers from previous assessments" in {
+      "and save the category information without copying answers from previous assessments" - {
 
-        when(mockCategorisationService.getCategorisationInfo(any(), any(), any(), any(), any())(any())).thenReturn(
-          Future.successful(categorisationInfo)
-        )
+        "when the longer commodity code was already set to the same value" in {
 
-        val shorterCommodity = categorisationInfo.copy(commodityCode = "123456")
-
-        val userAnswers = emptyUserAnswers
-          .set(CategorisationDetailsQuery(testRecordId), shorterCommodity)
-          .success
-          .value
-          .set(
-            LongerCommodityQuery(testRecordId),
-            longerCommodity
+          when(mockCategorisationService.getCategorisationInfo(any(), any(), any(), any(), any())(any())).thenReturn(
+            Future.successful(categorisationInfo)
           )
-          .success
-          .value
-          .set(
-            LongerCategorisationDetailsQuery(testRecordId),
-            categorisationInfo
-          )
-          .success
-          .value
 
-        val app = application(userAnswers)
-        running(app) {
+          val shorterCommodity = categorisationInfo.copy(commodityCode = "123456")
 
-          val request =
-            FakeRequest(
-              GET,
-              routes.CategorisationPreparationController.startLongerCategorisation(NormalMode, testRecordId).url
+          val userAnswers = emptyUserAnswers
+            .set(CategorisationDetailsQuery(testRecordId), shorterCommodity)
+            .success
+            .value
+            .set(
+              LongerCommodityQuery(testRecordId),
+              longerCommodity
             )
-          val result  = route(app, request).value
-          status(result) mustEqual SEE_OTHER
-          redirectLocation(result).value mustEqual onwardRoute.url
-
-          withClue("must get category details from categorisation service") {
-            verify(mockCategorisationService)
-              .getCategorisationInfo(any(), eqTo("1234567890"), eqTo("GB"), eqTo(testRecordId), eqTo(true))(any())
-          }
-
-          withClue("must not update answers from categorisation service as not needed") {
-            verify(mockCategorisationService, times(0))
-              .updatingAnswersForRecategorisation(any(), any(), any(), any())
-          }
-
-          withClue("must not have updated goods record") {
-            verify(mockGoodsRecordConnector, times(0)).updateCategoryAndComcodeForGoodsRecord(any(), any(), any())(
-              any()
+            .success
+            .value
+            .set(
+              LongerCategorisationDetailsQuery(testRecordId),
+              categorisationInfo
             )
-          }
+            .success
+            .value
 
+          val app = application(userAnswers)
+          running(app) {
+
+            val request =
+              FakeRequest(
+                GET,
+                routes.CategorisationPreparationController.startLongerCategorisation(NormalMode, testRecordId).url
+              )
+            val result  = route(app, request).value
+            status(result) mustEqual SEE_OTHER
+            redirectLocation(result).value mustEqual onwardRoute.url
+
+            withClue("must get category details from categorisation service") {
+              verify(mockCategorisationService)
+                .getCategorisationInfo(any(), eqTo("1234567890"), eqTo("GB"), eqTo(testRecordId), eqTo(true))(any())
+            }
+
+            withClue("must not update answers from categorisation service as not needed") {
+              verify(mockCategorisationService, times(0))
+                .updatingAnswersForRecategorisation(any(), any(), any(), any())
+            }
+
+            withClue("must not have updated goods record") {
+              verify(mockGoodsRecordConnector, times(0)).updateCategoryAndComcodeForGoodsRecord(any(), any(), any())(
+                any()
+              )
+            }
+
+          }
         }
-
       }
     }
 

--- a/test/controllers/CyaCategorisationControllerSpec.scala
+++ b/test/controllers/CyaCategorisationControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import base.TestConstants.{testEori, testRecordId}
 import connectors.GoodsRecordConnector
 import models.helper.CategorisationJourney
-import models.{AssessmentAnswer, Category1Scenario, CategoryRecord, UserAnswers}
+import models.{AssessmentAnswer, Category1Scenario, CategoryRecord, ReassessmentAnswer, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
 import org.apache.pekko.Done
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
@@ -280,10 +280,10 @@ class CyaCategorisationControllerSpec extends SpecBase with SummaryListFluency w
             .set(LongerCommodityCodePage(testRecordId), "3210")
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.NoExemption)
+            .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.NoExemption))
             .success
             .value
 

--- a/test/models/CategorisationAnswersSpec.scala
+++ b/test/models/CategorisationAnswersSpec.scala
@@ -322,7 +322,7 @@ class CategorisationAnswersSpec extends SpecBase {
 
         "a NoExemption means the following assessment pages are unanswered" in {
           val answers = longerCommodityBaseAnswers
-            .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.NoExemption)
+            .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.NoExemption))
             .success
             .value
 
@@ -336,13 +336,13 @@ class CategorisationAnswersSpec extends SpecBase {
         "all assessments are answered Yes" in {
 
           val answers = longerCommodityBaseAnswers
-            .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
 
@@ -366,13 +366,13 @@ class CategorisationAnswersSpec extends SpecBase {
 
           val answers =
             longerCommodityBaseAnswers
-              .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+              .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
               .success
               .value
-              .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+              .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
               .success
               .value
-              .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.Exemption)
+              .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
               .success
               .value
 
@@ -396,13 +396,13 @@ class CategorisationAnswersSpec extends SpecBase {
 
           val answers =
             longerCommodityBaseAnswers
-              .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+              .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
               .success
               .value
-              .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+              .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
               .success
               .value
-              .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.NoExemption)
+              .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NoExemption))
               .success
               .value
               .set(HasSupplementaryUnitPage(testRecordId), false)
@@ -429,13 +429,13 @@ class CategorisationAnswersSpec extends SpecBase {
 
           val answers =
             longerCommodityBaseAnswers
-              .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+              .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
               .success
               .value
-              .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+              .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
               .success
               .value
-              .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.NoExemption)
+              .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NoExemption))
               .success
               .value
               .set(HasSupplementaryUnitPage(testRecordId), true)
@@ -467,13 +467,13 @@ class CategorisationAnswersSpec extends SpecBase {
 
           val answers =
             longerCommodityBaseAnswers
-              .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+              .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
               .success
               .value
-              .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+              .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
               .success
               .value
-              .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.NoExemption)
+              .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NoExemption))
               .success
               .value
               .set(HasSupplementaryUnitPage(testRecordId), true)
@@ -491,13 +491,13 @@ class CategorisationAnswersSpec extends SpecBase {
 
           val answers =
             longerCommodityBaseAnswers
-              .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+              .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
               .success
               .value
-              .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+              .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
               .success
               .value
-              .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.NoExemption)
+              .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NoExemption))
               .success
               .value
               .set(SupplementaryUnitPage(testRecordId), "42.0")
@@ -561,13 +561,13 @@ class CategorisationAnswersSpec extends SpecBase {
             )
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.NoExemption)
+            .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.NoExemption))
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
 
@@ -599,10 +599,10 @@ class CategorisationAnswersSpec extends SpecBase {
             )
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
 
@@ -636,13 +636,13 @@ class CategorisationAnswersSpec extends SpecBase {
             )
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.NotAnsweredYet)
+            .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.NoExemption)
+            .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NoExemption))
             .success
             .value
 
@@ -676,13 +676,13 @@ class CategorisationAnswersSpec extends SpecBase {
             )
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
 

--- a/test/models/CategoryRecordSpec.scala
+++ b/test/models/CategoryRecordSpec.scala
@@ -255,7 +255,7 @@ class CategoryRecordSpec extends SpecBase with BeforeAndAfterEach {
             .set(LongerCategorisationDetailsQuery(testRecordId), longerCat)
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.NoExemption)
+            .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.NoExemption))
             .success
             .value
 

--- a/test/models/ott/CategorisationInfoSpec.scala
+++ b/test/models/ott/CategorisationInfoSpec.scala
@@ -19,7 +19,7 @@ package models.ott
 import base.SpecBase
 import base.TestConstants.{NiphlsCode, testRecordId}
 import models.ott.response._
-import models.{AnsweredQuestions, AssessmentAnswer, TraderProfile}
+import models.{AnsweredQuestions, AssessmentAnswer, ReassessmentAnswer, TraderProfile}
 import pages.{AssessmentPage, ReassessmentPage}
 import queries.{CategorisationDetailsQuery, LongerCategorisationDetailsQuery}
 
@@ -985,13 +985,13 @@ class CategorisationInfoSpec extends SpecBase {
           .set(LongerCategorisationDetailsQuery(testRecordId), longerCommodity)
           .success
           .value
-          .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+          .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
           .success
           .value
-          .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+          .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
           .success
           .value
-          .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.NoExemption)
+          .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NoExemption))
           .success
           .value
 

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -1618,10 +1618,16 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 0),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 1),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
                 .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
@@ -1642,10 +1648,16 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 0),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.NoExemption))
+                .set(
+                  ReassessmentPage(testRecordId, 1),
+                  ReassessmentAnswer(AssessmentAnswer.NoExemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
 
@@ -1659,13 +1671,22 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 0),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 1),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 2),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
 
@@ -1792,10 +1813,16 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 0),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 1),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
 
@@ -1810,13 +1837,22 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 0),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 1),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
+                  .set(
+                    ReassessmentPage(testRecordId, 2),
+                    ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
 
@@ -3421,10 +3457,16 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 0),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 1),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
 
@@ -3439,13 +3481,22 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 0),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 1),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
+                  .set(
+                    ReassessmentPage(testRecordId, 2),
+                    ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
 

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -1578,7 +1578,7 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.NotAnsweredYet)
+                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
                 .success
                 .value
 
@@ -1595,10 +1595,10 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
 
@@ -1612,13 +1612,13 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.NotAnsweredYet)
+                .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
                 .success
                 .value
 
@@ -1636,10 +1636,10 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.NoExemption)
+                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.NoExemption))
                 .success
                 .value
 
@@ -1653,13 +1653,13 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
 
@@ -1749,7 +1749,7 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
 
@@ -1764,10 +1764,10 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.NotAnsweredYet)
+                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
                   .success
                   .value
 
@@ -1786,10 +1786,10 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
 
@@ -1804,13 +1804,13 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.NotAnsweredYet)
+                  .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
                   .success
                   .value
 
@@ -1830,13 +1830,13 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                     .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                     .success
                     .value
-                    .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                    .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                     .success
                     .value
-                    .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                    .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                     .success
                     .value
-                    .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.Exemption)
+                    .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
                     .success
                     .value
 
@@ -1851,10 +1851,10 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                     .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                     .success
                     .value
-                    .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                    .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                     .success
                     .value
-                    .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.NoExemption)
+                    .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.NoExemption))
                     .success
                     .value
 
@@ -1872,13 +1872,13 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                     )
                     .success
                     .value
-                    .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                    .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                     .success
                     .value
-                    .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                    .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                     .success
                     .value
-                    .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.NoExemption)
+                    .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NoExemption))
                     .success
                     .value
 
@@ -1894,7 +1894,7 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.NoExemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.NoExemption))
                   .success
                   .value
 
@@ -1909,13 +1909,13 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo.copy(measurementUnit = None))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.NoExemption)
+                  .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NoExemption))
                   .success
                   .value
 
@@ -1932,13 +1932,13 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.NoExemption)
+                .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NoExemption))
                 .success
                 .value
 
@@ -1971,16 +1971,16 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 3), AssessmentAnswer.NoExemption)
+                  .set(ReassessmentPage(testRecordId, 3), ReassessmentAnswer(AssessmentAnswer.NoExemption))
                   .success
                   .value
 
@@ -3195,7 +3195,7 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.NotAnsweredYet)
+                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
                 .success
                 .value
 
@@ -3212,10 +3212,10 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
 
@@ -3229,13 +3229,13 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.NotAnsweredYet)
+                .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
                 .success
                 .value
 
@@ -3253,10 +3253,10 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.NoExemption)
+                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.NoExemption))
                 .success
                 .value
 
@@ -3270,13 +3270,13 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
 
@@ -3366,7 +3366,7 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
 
@@ -3381,10 +3381,10 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.NotAnsweredYet)
+                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
                   .success
                   .value
 
@@ -3403,10 +3403,10 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
 
@@ -3421,13 +3421,13 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.NotAnsweredYet)
+                  .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
                   .success
                   .value
 
@@ -3445,13 +3445,13 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
 
@@ -3466,10 +3466,10 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.NoExemption)
+                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.NoExemption))
                   .success
                   .value
 
@@ -3484,13 +3484,13 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
 
@@ -3505,7 +3505,7 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.NoExemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.NoExemption))
                   .success
                   .value
 
@@ -3520,13 +3520,13 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo.copy(measurementUnit = None))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.NoExemption)
+                  .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NoExemption))
                   .success
                   .value
 
@@ -3543,13 +3543,13 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.NoExemption)
+                .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NoExemption))
                 .success
                 .value
 
@@ -3582,16 +3582,16 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.Exemption)
+                  .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 3), AssessmentAnswer.NoExemption)
+                  .set(ReassessmentPage(testRecordId, 3), ReassessmentAnswer(AssessmentAnswer.NoExemption))
                   .success
                   .value
 

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -1595,10 +1595,16 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 0),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 1),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
 
@@ -3212,10 +3218,16 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 0),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 1),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
 
@@ -3229,10 +3241,16 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 0),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 1),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
                 .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -1587,7 +1587,7 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
 
             }
 
-            "first reassessment is answered but answer is not copied" in {
+            "first reassessment is answered but answer was not copied from shorter assessment" in {
               val userAnswers = emptyUserAnswers
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
@@ -1812,6 +1812,24 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .success
                   .value
                   .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
+                  .success
+                  .value
+
+              navigator.nextPage(ReassessmentPage(testRecordId, 0), NormalMode, userAnswers) mustEqual
+                routes.AssessmentController.onPageLoadReassessment(NormalMode, testRecordId, 1)
+
+            }
+
+            "and next question is answered but was not copied from shorter assessment" in {
+              val userAnswers =
+                emptyUserAnswers
+                  .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
+                  .success
+                  .value
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .success
+                  .value
+                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
                   .success
                   .value
 
@@ -3278,7 +3296,7 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
 
             }
 
-            "first reassessment is answered but answer is not copied" in {
+            "first reassessment is answered but answer was not copied from shorter assessment" in {
               val userAnswers = emptyUserAnswers
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
@@ -3511,6 +3529,23 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
 
             }
 
+            "and next question is answered but was not copied from shorter assessment" in {
+              val userAnswers =
+                emptyUserAnswers
+                  .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
+                  .success
+                  .value
+                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .success
+                  .value
+                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .success
+                  .value
+
+              navigator.nextPage(ReassessmentPage(testRecordId, 0), CheckMode, userAnswers) mustEqual
+                routes.AssessmentController.onPageLoadReassessment(CheckMode, testRecordId, 1)
+
+            }
           }
 
           "to a later reassessment if the next one is answered yes" - {

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -1586,6 +1586,23 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 routes.AssessmentController.onPageLoadReassessment(NormalMode, testRecordId, 0)
 
             }
+
+            "first reassessment is answered but answer is not copied" in {
+              val userAnswers = emptyUserAnswers
+                .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
+                .success
+                .value
+                .set(
+                  ReassessmentPage(testRecordId, 0),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption)
+                )
+                .success
+                .value
+
+              navigator.nextPage(RecategorisationPreparationPage(testRecordId), NormalMode, userAnswers) mustEqual
+                routes.AssessmentController.onPageLoadReassessment(NormalMode, testRecordId, 0)
+
+            }
           }
 
           "to the third assessment page when the first two are answered" - {
@@ -3253,6 +3270,23 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .success
                 .value
                 .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
+                .success
+                .value
+
+              navigator.nextPage(RecategorisationPreparationPage(testRecordId), CheckMode, userAnswers) mustEqual
+                routes.AssessmentController.onPageLoadReassessment(CheckMode, testRecordId, 0)
+
+            }
+
+            "first reassessment is answered but answer is not copied" in {
+              val userAnswers = emptyUserAnswers
+                .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
+                .success
+                .value
+                .set(
+                  ReassessmentPage(testRecordId, 0),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption)
+                )
                 .success
                 .value
 

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -1893,10 +1893,16 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                     .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                     .success
                     .value
-                    .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                    .set(
+                      ReassessmentPage(testRecordId, 0),
+                      ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                    )
                     .success
                     .value
-                    .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.NoExemption))
+                    .set(
+                      ReassessmentPage(testRecordId, 1),
+                      ReassessmentAnswer(AssessmentAnswer.NoExemption, isAnswerCopiedFromPreviousAssessment = true)
+                    )
                     .success
                     .value
 
@@ -1914,13 +1920,22 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                     )
                     .success
                     .value
-                    .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                    .set(
+                      ReassessmentPage(testRecordId, 0),
+                      ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                    )
                     .success
                     .value
-                    .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                    .set(
+                      ReassessmentPage(testRecordId, 1),
+                      ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                    )
                     .success
                     .value
-                    .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.NoExemption))
+                    .set(
+                      ReassessmentPage(testRecordId, 2),
+                      ReassessmentAnswer(AssessmentAnswer.NoExemption, isAnswerCopiedFromPreviousAssessment = true)
+                    )
                     .success
                     .value
 
@@ -3307,10 +3322,16 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 0),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.NoExemption))
+                .set(
+                  ReassessmentPage(testRecordId, 1),
+                  ReassessmentAnswer(AssessmentAnswer.NoExemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
 
@@ -3324,13 +3345,22 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 0),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 1),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
-                .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                .set(
+                  ReassessmentPage(testRecordId, 2),
+                  ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                )
                 .success
                 .value
 
@@ -3514,13 +3544,22 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 0),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 1),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 2),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
 
@@ -3535,10 +3574,16 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 0),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.NoExemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 1),
+                    ReassessmentAnswer(AssessmentAnswer.NoExemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
 
@@ -3553,13 +3598,22 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 0),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 1),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
-                  .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
+                  .set(
+                    ReassessmentPage(testRecordId, 2),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+                  )
                   .success
                   .value
 

--- a/test/pages/LongerCommodityCodePageSpec.scala
+++ b/test/pages/LongerCommodityCodePageSpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+import base.SpecBase
+import base.TestConstants.{testRecordId, userAnswersId}
+import models.{Commodity, UserAnswers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.{OptionValues, TryValues}
+import queries.{CategorisationDetailsQuery, LongerCommodityQuery}
+
+import java.time.Instant
+
+class LongerCommodityCodePageSpec extends SpecBase {
+
+  "clean up" - {
+
+    "does not removes HasCorrectGoodsLongerCommodityCodePage when longer commodity is same" in {
+
+      val userAnswers = UserAnswers(userAnswersId)
+        .set(HasCorrectGoodsLongerCommodityCodePage(testRecordId), true)
+        .success
+        .value
+
+      val result = userAnswers
+        .set(
+          LongerCommodityQuery(testRecordId),
+          Commodity("1234567890", List("Description", "Other"), Instant.now, None)
+        )
+        .success
+        .value
+        .set(CategorisationDetailsQuery(testRecordId), categorisationInfo.copy(commodityCode = "123456"))
+        .success
+        .value
+        .set(LongerCommodityCodePage(testRecordId), "7890")
+        .success
+        .value
+
+      result.isDefined(HasCorrectGoodsLongerCommodityCodePage(testRecordId)) mustBe true
+
+      result.get(HasCorrectGoodsLongerCommodityCodePage(testRecordId)) mustBe Some(true)
+    }
+
+    "removes HasCorrectGoodsLongerCommodityCodePage when longer commodity is different" in {
+
+      val userAnswers = UserAnswers(userAnswersId)
+        .set(HasCorrectGoodsLongerCommodityCodePage(testRecordId), true)
+        .success
+        .value
+
+      val result = userAnswers
+        .set(
+          LongerCommodityQuery(testRecordId),
+          Commodity("1234567890", List("Description", "Other"), Instant.now, None)
+        )
+        .success
+        .value
+        .set(CategorisationDetailsQuery(testRecordId), categorisationInfo.copy(commodityCode = "123456"))
+        .success
+        .value
+        .set(LongerCommodityCodePage(testRecordId), "1234")
+        .success
+        .value
+
+      result.isDefined(HasCorrectGoodsLongerCommodityCodePage(testRecordId)) mustBe false
+
+    }
+
+  }
+}

--- a/test/pages/ReassessmentPageSpec.scala
+++ b/test/pages/ReassessmentPageSpec.scala
@@ -18,7 +18,7 @@ package pages
 
 import base.SpecBase
 import base.TestConstants.testRecordId
-import models.AssessmentAnswer
+import models.{AssessmentAnswer, ReassessmentAnswer}
 import models.ott._
 import queries.LongerCategorisationDetailsQuery
 
@@ -58,17 +58,18 @@ class ReassessmentPageSpec extends SpecBase {
             .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
 
-        val result = answers.set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption).success.value
+        val result =
+          answers.set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption)).success.value
 
         result.isDefined(ReassessmentPage(testRecordId, 0)) mustBe true
         result.isDefined(ReassessmentPage(testRecordId, 1)) mustBe true
@@ -85,20 +86,21 @@ class ReassessmentPageSpec extends SpecBase {
             .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
-            .set(ReassessmentPage(testRecordId, 3), AssessmentAnswer.Exemption)
+            .set(ReassessmentPage(testRecordId, 3), ReassessmentAnswer(AssessmentAnswer.Exemption))
             .success
             .value
 
-        val result = answers.set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.NoExemption).success.value
+        val result =
+          answers.set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.NoExemption)).success.value
 
         result.isDefined(ReassessmentPage(testRecordId, 0)) mustBe true
         result.isDefined(ReassessmentPage(testRecordId, 1)) mustBe true

--- a/test/services/CategorisationServiceSpec.scala
+++ b/test/services/CategorisationServiceSpec.scala
@@ -23,7 +23,7 @@ import models.ott.{CategoryAssessment, _}
 import models.ott.response.{CategoryAssessmentRelationship, ExemptionType => ResponseExemptionType, _}
 import models.requests.DataRequest
 import models.router.responses.GetGoodsRecordResponse
-import models.{AssessmentAnswer, Category1NoExemptionsScenario, Category1Scenario, Category2Scenario, StandardGoodsNoAssessmentsScenario, StandardGoodsScenario, TraderProfile}
+import models.{AssessmentAnswer, Category1NoExemptionsScenario, Category1Scenario, Category2Scenario, ReassessmentAnswer, StandardGoodsNoAssessmentsScenario, StandardGoodsScenario, TraderProfile}
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
@@ -835,13 +835,13 @@ class CategorisationServiceSpec extends SpecBase with BeforeAndAfterEach {
 
     "should return the user answers with the reassessment answers set if old and new category assessments are the same" in {
       val expectedUserAnswers = userAnswersForCategorisation
-        .set(ReassessmentPage(testRecordId, 0), AssessmentAnswer.Exemption)
+        .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
         .success
         .value
-        .set(ReassessmentPage(testRecordId, 1), AssessmentAnswer.Exemption)
+        .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
         .success
         .value
-        .set(ReassessmentPage(testRecordId, 2), AssessmentAnswer.Exemption)
+        .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
         .success
         .value
 

--- a/test/services/CategorisationServiceSpec.scala
+++ b/test/services/CategorisationServiceSpec.scala
@@ -835,13 +835,22 @@ class CategorisationServiceSpec extends SpecBase with BeforeAndAfterEach {
 
     "should return the user answers with the reassessment answers set if old and new category assessments are the same" in {
       val expectedUserAnswers = userAnswersForCategorisation
-        .set(ReassessmentPage(testRecordId, 0), ReassessmentAnswer(AssessmentAnswer.Exemption))
+        .set(
+          ReassessmentPage(testRecordId, 0),
+          ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+        )
         .success
         .value
-        .set(ReassessmentPage(testRecordId, 1), ReassessmentAnswer(AssessmentAnswer.Exemption))
+        .set(
+          ReassessmentPage(testRecordId, 1),
+          ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+        )
         .success
         .value
-        .set(ReassessmentPage(testRecordId, 2), ReassessmentAnswer(AssessmentAnswer.Exemption))
+        .set(
+          ReassessmentPage(testRecordId, 2),
+          ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true)
+        )
         .success
         .value
 
@@ -877,7 +886,7 @@ class CategorisationServiceSpec extends SpecBase with BeforeAndAfterEach {
         .success
         .value
 
-      result.get(ReassessmentPage(testRecordId, 0)) shouldBe Some(AssessmentAnswer.NotAnsweredYet)
+      result.get(ReassessmentPage(testRecordId, 0)) shouldBe Some(ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
       result.get(ReassessmentPage(testRecordId, 1)) shouldBe None
       result.get(ReassessmentPage(testRecordId, 2)) shouldBe None
     }
@@ -906,9 +915,12 @@ class CategorisationServiceSpec extends SpecBase with BeforeAndAfterEach {
         )
         .success
         .value
-      result.get(ReassessmentPage(testRecordId, 0)) shouldBe Some(AssessmentAnswer.Exemption)
-      result.get(ReassessmentPage(testRecordId, 1)) shouldBe Some(AssessmentAnswer.Exemption)
-      result.get(ReassessmentPage(testRecordId, 2)) shouldBe Some(AssessmentAnswer.Exemption)
+      result.get(ReassessmentPage(testRecordId, 0)) shouldBe
+        Some(ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true))
+      result.get(ReassessmentPage(testRecordId, 1)) shouldBe
+        Some(ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true))
+      result.get(ReassessmentPage(testRecordId, 2)) shouldBe
+        Some(ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true))
     }
 
     "should copy the old answers to the right position if they are in different order in the new categorisation" in {
@@ -949,10 +961,14 @@ class CategorisationServiceSpec extends SpecBase with BeforeAndAfterEach {
         )
         .success
         .value
-      newUserAnswers.get(ReassessmentPage(testRecordId, 0)) mustBe Some(AssessmentAnswer.Exemption)
-      newUserAnswers.get(ReassessmentPage(testRecordId, 1)) mustBe Some(AssessmentAnswer.Exemption)
-      newUserAnswers.get(ReassessmentPage(testRecordId, 2)) mustBe Some(AssessmentAnswer.NotAnsweredYet)
-      newUserAnswers.get(ReassessmentPage(testRecordId, 3)) mustBe Some(AssessmentAnswer.Exemption)
+      newUserAnswers.get(ReassessmentPage(testRecordId, 0)) mustBe
+        Some(ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true))
+      newUserAnswers.get(ReassessmentPage(testRecordId, 1)) mustBe
+        Some(ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true))
+      newUserAnswers.get(ReassessmentPage(testRecordId, 2)) mustBe
+        Some(ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
+      newUserAnswers.get(ReassessmentPage(testRecordId, 3)) mustBe
+        Some(ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true))
     }
 
     "should move the old answers to the right position if only some are in the new categorisation" in {
@@ -990,8 +1006,10 @@ class CategorisationServiceSpec extends SpecBase with BeforeAndAfterEach {
         )
         .success
         .value
-      newUserAnswers.get(ReassessmentPage(testRecordId, 0)) mustBe Some(AssessmentAnswer.Exemption)
-      newUserAnswers.get(ReassessmentPage(testRecordId, 1)) mustBe Some(AssessmentAnswer.NotAnsweredYet)
+      newUserAnswers.get(ReassessmentPage(testRecordId, 0)) mustBe
+        Some(ReassessmentAnswer(AssessmentAnswer.Exemption, isAnswerCopiedFromPreviousAssessment = true))
+      newUserAnswers.get(ReassessmentPage(testRecordId, 1)) mustBe
+        Some(ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet))
       newUserAnswers.get(ReassessmentPage(testRecordId, 2)) mustBe None
     }
 


### PR DESCRIPTION
**Fix for Recategorisation Answers Not Saving When Navigating Back and Forth Using the Back Button**

This is to ensures that when a user completes the recategorisation journey and reaches the CYA page, their recategorisation answers are saved correctly, even if they use the back button to navigate back and forth through the journey.

