### PR TITLE
TGP-2558: Hidden span causing page to continue scrolling after table.

### DIFF
--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -46,8 +46,7 @@
     signOutUrl: String = controllers.auth.routes.AuthController.signOutNoSurvey.url,
     isFullWidth: Boolean = false,
     extraHead: Html = HtmlFormat.empty,
-    headerShouldHaveServiceLink: Boolean = true,
-    shrinkHiddenSpans: Boolean = false
+    headerShouldHaveServiceLink: Boolean = true
     )(contentBlock: Html)(implicit request: Request[_], messages: Messages)
 
 @head = {

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -46,7 +46,8 @@
     signOutUrl: String = controllers.auth.routes.AuthController.signOutNoSurvey.url,
     isFullWidth: Boolean = false,
     extraHead: Html = HtmlFormat.empty,
-    headerShouldHaveServiceLink: Boolean = true
+    headerShouldHaveServiceLink: Boolean = true,
+    shrinkHiddenSpans: Boolean = false
     )(contentBlock: Html)(implicit request: Request[_], messages: Messages)
 
 @head = {
@@ -68,6 +69,11 @@
     )
     <link href="@routes.Assets.versioned("stylesheets/accessible-autocomplete.min.css").url" media="screen" rel="stylesheet" type="text/css" />
     <link href="@routes.Assets.versioned("stylesheets/application.css")" media="all" rel="stylesheet" type="text/css" />
+    <style>
+        span.govuk-visually-hidden {
+            max-width: 0px !important;
+        }
+    </style>
     @extraHead
 }
 


### PR DESCRIPTION
How does one look for, find, debug, and fix a problem that is invisible?!

I remade the entire table but didn't include the spans because they were visually hidden anyway, and it was fine. Bewildered, I popped the spans back in. VOILA, the bug came back.

So I instead ditched my remake and applied a max width of 0 to the visually hidden spans. *Sigh* ... at last ... it is done.

## **1 PIXEL** of width on a **_visually hidden_** span was causing all of my anguish.