### PR TITLE
TGP-2808: Categorisation Nav Bugfix

### DIFF
--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -564,26 +564,25 @@ class Navigator @Inject() (categorisationService: CategorisationService) {
   }
 
   private def navigateFromReassessmentCheck(assessmentPage: ReassessmentPage)(answers: UserAnswers): Call = {
-    val recordId = assessmentPage.recordId
-    val nextIndex = assessmentPage.index + 1
+    val recordId   = assessmentPage.recordId
+    val nextIndex  = assessmentPage.index + 1
     val nextNumber = nextIndex + 1
 
     for {
       categorisationInfo <- answers.get(LongerCategorisationDetailsQuery(recordId))
-      assessmentCount = categorisationInfo.categoryAssessmentsThatNeedAnswers.size
+      assessmentCount     = categorisationInfo.categoryAssessmentsThatNeedAnswers.size
       assessmentQuestion <- categorisationInfo.getAssessmentFromIndex(assessmentPage.index)
-      assessmentAnswer <- answers.get(assessmentPage)
-      nextAnswer = answers.get(ReassessmentPage(recordId, nextIndex))
+      assessmentAnswer   <- answers.get(assessmentPage)
+      nextAnswer          = answers.get(ReassessmentPage(recordId, nextIndex))
     } yield assessmentAnswer.answer match {
-      case AssessmentAnswer.Exemption(_)
-        if nextIndex < assessmentCount && reassessmentAnswerIsEmpty(nextAnswer) =>
+      case AssessmentAnswer.Exemption(_) if nextIndex < assessmentCount && reassessmentAnswerIsEmpty(nextAnswer) =>
         routes.AssessmentController.onPageLoadReassessment(CheckMode, recordId, nextNumber)
-      case AssessmentAnswer.Exemption(_) if nextIndex < assessmentCount =>
+      case AssessmentAnswer.Exemption(_) if nextIndex < assessmentCount                                          =>
         navigateFromReassessmentCheck(ReassessmentPage(recordId, nextIndex))(answers)
       case AssessmentAnswer.NoExemption
-        if shouldGoToSupplementaryUnitCheck(answers, categorisationInfo, assessmentQuestion, recordId) =>
+          if shouldGoToSupplementaryUnitCheck(answers, categorisationInfo, assessmentQuestion, recordId) =>
         routes.HasSupplementaryUnitController.onPageLoad(CheckMode, recordId)
-      case _ =>
+      case _                                                                                                     =>
         routes.CyaCategorisationController.onPageLoad(recordId)
     }
   } getOrElse routes.JourneyRecoveryController.onPageLoad()

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -564,28 +564,26 @@ class Navigator @Inject() (categorisationService: CategorisationService) {
   }
 
   private def navigateFromReassessmentCheck(assessmentPage: ReassessmentPage)(answers: UserAnswers): Call = {
-    val recordId   = assessmentPage.recordId
-    val nextIndex  = assessmentPage.index + 1
+    val recordId = assessmentPage.recordId
+    val nextIndex = assessmentPage.index + 1
     val nextNumber = nextIndex + 1
 
     for {
       categorisationInfo <- answers.get(LongerCategorisationDetailsQuery(recordId))
-      assessmentCount     = categorisationInfo.categoryAssessmentsThatNeedAnswers.size
+      assessmentCount = categorisationInfo.categoryAssessmentsThatNeedAnswers.size
       assessmentQuestion <- categorisationInfo.getAssessmentFromIndex(assessmentPage.index)
-      assessmentAnswer   <- answers.get(assessmentPage)
-      nextAnswer          = answers.get(ReassessmentPage(recordId, nextIndex))
+      assessmentAnswer <- answers.get(assessmentPage)
+      nextAnswer = answers.get(ReassessmentPage(recordId, nextIndex))
     } yield assessmentAnswer.answer match {
       case AssessmentAnswer.Exemption(_)
-          if nextIndex < assessmentCount && (reassessmentAnswerIsEmpty(nextAnswer) || !nextAnswer.exists(
-            _.isAnswerCopiedFromPreviousAssessment
-          )) =>
+        if nextIndex < assessmentCount && reassessmentAnswerIsEmpty(nextAnswer) =>
         routes.AssessmentController.onPageLoadReassessment(CheckMode, recordId, nextNumber)
       case AssessmentAnswer.Exemption(_) if nextIndex < assessmentCount =>
         navigateFromReassessmentCheck(ReassessmentPage(recordId, nextIndex))(answers)
       case AssessmentAnswer.NoExemption
-          if shouldGoToSupplementaryUnitCheck(answers, categorisationInfo, assessmentQuestion, recordId) =>
+        if shouldGoToSupplementaryUnitCheck(answers, categorisationInfo, assessmentQuestion, recordId) =>
         routes.HasSupplementaryUnitController.onPageLoad(CheckMode, recordId)
-      case _                                                            =>
+      case _ =>
         routes.CyaCategorisationController.onPageLoad(recordId)
     }
   } getOrElse routes.JourneyRecoveryController.onPageLoad()

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -4861,30 +4861,6 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                 routes.AssessmentController.onPageLoadReassessment(CheckMode, testRecordId, 2)
 
             }
-
-            "and next question is answered but was not copied from shorter assessment" in {
-              val userAnswers =
-                emptyUserAnswers
-                  .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
-                  .success
-                  .value
-                  .set(
-                    ReassessmentPage(testRecordId, 0),
-                    ReassessmentAnswer(AssessmentAnswer.Exemption(Seq("TEST_CODE")))
-                  )
-                  .success
-                  .value
-                  .set(
-                    ReassessmentPage(testRecordId, 1),
-                    ReassessmentAnswer(AssessmentAnswer.Exemption(Seq("TEST_CODE")))
-                  )
-                  .success
-                  .value
-
-              navigator.nextPage(ReassessmentPage(testRecordId, 0), CheckMode, userAnswers) mustEqual
-                routes.AssessmentController.onPageLoadReassessment(CheckMode, testRecordId, 2)
-
-            }
           }
 
           "to a later reassessment if the next one is answered yes" - {
@@ -4946,6 +4922,30 @@ class NavigatorSpec extends SpecBase with BeforeAndAfterEach {
                   .set(
                     ReassessmentPage(testRecordId, 2),
                     ReassessmentAnswer(AssessmentAnswer.NotAnsweredYet, isAnswerCopiedFromPreviousAssessment = true)
+                  )
+                  .success
+                  .value
+
+              navigator.nextPage(ReassessmentPage(testRecordId, 0), CheckMode, userAnswers) mustEqual
+                routes.AssessmentController.onPageLoadReassessment(CheckMode, testRecordId, 3)
+
+            }
+
+            "and next question is answered but was not copied from shorter assessment" in {
+              val userAnswers =
+                emptyUserAnswers
+                  .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
+                  .success
+                  .value
+                  .set(
+                    ReassessmentPage(testRecordId, 0),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption(Seq("TEST_CODE")))
+                  )
+                  .success
+                  .value
+                  .set(
+                    ReassessmentPage(testRecordId, 1),
+                    ReassessmentAnswer(AssessmentAnswer.Exemption(Seq("TEST_CODE")), true)
                   )
                   .success
                   .value


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/TGP-2808

Effectively, in check mode for reassessments, we can skip the check for if the answer was copied from a previous assessment. This check, if it evaluates false, is pretty much assuming that the user would not have answered that yet, which would be the case in NormalMode.

CheckMode is different, the above assumption can be false. For instance, they fill out the reassessment answers, then click change on one of them, and submit. (See the steps to reproduce bug in Jira ticket, which confirm this)

To solve this, all we care about is, “Is there an assessment answer the user needs to provide?”, and we shouldn’t be assuming that they haven’t provided them.

This small PR deals removes the check, and by doing so, removes that assumption. I can’t think of any case in CheckMode where we need it. The redirecting to CYA was already working perfectly fine except for in this one tiny case, as @mohsinkits  found and @kenneth-rayner elaborated the thinking on.

Now, in check mode, it should only NOT redirect to CYA when there are actually new answers to fill.

# Checklist for developers before reviewing
 - [x] I have merged in main
 - [x] I have assigned the PR to me
 - [x] I ran the code with a clean compile test and ensured there are no warnings or deprecations
 - [x] I have run `sbt prePR` to run all tests, format and check the code coverage
 - [x] I have written unit tests to cover any code that I wrote, where necessary
 - [x] I have linked tickets to any TODOs I have written
 - [x] I have run the microservices with the latest SM2 config
 - [x] I have checked all the Acceptance Criteria pass
 - [x] I have run the pipeline journey tests
 - [x] I have run the local journey tests
 - [x] I have spoken to the QAs about any changes that may need to be made to the journey tests OR no changes to the journey tests are necessary
 - [x] I have moved the ticket to Review in Jira
 - [x] I have left a message in tgp-prs on slack to alert other Devs that this ticket is ready for review
 - [x] I have checked my PR is not in draft mode

# Checklist for reviewer 1
- [x] I have added an emoji to the relevant message in tgp-prs to show I am reviewing
- [x] I have checked out the branch
- [x] I have run the microservices with the latest SM2 config
- [x] I have checked all the Acceptance Criteria pass
- [x] I reviewed the code and left comments where necessary
- [x] I have left a message on the relevant tgp-prs message to show that I have finished reviewing

# Checklist for reviewer 2
- [x] I have added an emoji to the relevant message in tgp-prs to show I am reviewing
- [x] I have checked out the branch
- [x] I have run the microservices with the latest SM2 config
- [x] I have checked all the Acceptance Criteria pass
- [x] I reviewed the code and left comments where necessary
- [x] I have left a message on the relevant tgp-prs message to show that I have finished reviewing

# Checklist for developers before merging
 - [ ] The PR has been approved by 2 other developers
 - [ ] I have merged in main
 - [ ] I have run `sbt preMerge` to run all tests, check formatting and code coverage
 - [ ] I have run the microservices with the latest SM2 config
 - [ ] I have checked all the Acceptance Criteria pass
 - [ ] I have checked that the QAs have merged in any changes to the journey tests
 - [ ] I have run the pipeline journey tests
 - [ ] I have run the local journey tests

# Reminders for developers after merging
 1. Wait for pipeline to pass
 2. Move ticket to QA column in Jira
 3. Leave message in tgp-qa on slack to alert QAs that this ticket is ready for testing
