### PR TITLE
TGP-2815: Categorisation Nav Bug fix

### DIFF
--- a/app/controllers/categorisation/CategorisationPreparationController.scala
+++ b/app/controllers/categorisation/CategorisationPreparationController.scala
@@ -123,16 +123,17 @@ class CategorisationPreparationController @Inject() (
                                           shorterCategorisationInfo
                                         )
 
-        _ <- updateCategory(
-               updatedUAReassessmentAnswers,
-               request.eori,
-               request.affinityGroup,
-               recordId,
-               newLongerCategorisationInfo
-             )
-        _ <- sessionRepository.set(updatedUAReassessmentAnswers)
+        _                    <- updateCategory(
+                                  updatedUAReassessmentAnswers,
+                                  request.eori,
+                                  request.affinityGroup,
+                                  recordId,
+                                  newLongerCategorisationInfo
+                                )
+        reorderedUserAnswers <-
+          categorisationService.reorderRecategorisationAnswers(updatedUAReassessmentAnswers, recordId)
       } yield Redirect(
-        navigator.nextPage(RecategorisationPreparationPage(recordId), mode, updatedUAReassessmentAnswers)
+        navigator.nextPage(RecategorisationPreparationPage(recordId), mode, reorderedUserAnswers)
       ))
         .recover { e =>
           logger.error(s"Unable to start categorisation for record $recordId: ${e.getMessage}")

--- a/app/navigation/CategorisationNavigator.scala
+++ b/app/navigation/CategorisationNavigator.scala
@@ -134,7 +134,7 @@ class CategorisationNavigator @Inject() (categorisationService: CategorisationSe
     val recordId = reasessmentPrep.recordId
 
     answers.get(LongerCategorisationDetailsQuery(recordId)) match {
-      case Some(catInfo) if catInfo.categoryAssessmentsThatNeedAnswers.nonEmpty =>
+      case Some(_) if categorisationService.existsUnansweredCat1Questions(answers, recordId) =>
         val firstAnswer = answers.get(ReassessmentPage(recordId, firstAssessmentIndex))
         if (reassessmentAnswerIsEmpty(firstAnswer) || !firstAnswer.get.isAnswerCopiedFromPreviousAssessment) {
           controllers.categorisation.routes.AssessmentController
@@ -147,13 +147,18 @@ class CategorisationNavigator @Inject() (categorisationService: CategorisationSe
         val scenario = categorisationService.calculateResult(catInfo, answers, recordId)
         if (shouldGoToSupplementaryUnitFromPrepPage(catInfo, scenario)) {
           controllers.categorisation.routes.HasSupplementaryUnitController.onPageLoad(CheckMode, recordId)
-        } else {
-          controllers.categorisation.routes.CategorisationResultController.onPageLoad(recordId, scenario)
-        }
-      case None          => controllers.problem.routes.JourneyRecoveryController.onPageLoad()
+        } else
+          scenario match {
+            case StandardGoodsNoAssessmentsScenario | Category1NoExemptionsScenario =>
+              controllers.categorisation.routes.CategorisationResultController.onPageLoad(recordId, scenario)
+            case _                                                                  => controllers.categorisation.routes.CyaCategorisationController.onPageLoad(recordId)
+          }
+
+      case None => controllers.problem.routes.JourneyRecoveryController.onPageLoad()
 
     }
   }
+
   private def navigateFromAssessmentCheck(assessmentPage: AssessmentPage)(answers: UserAnswers): Call = {
     val recordId   = assessmentPage.recordId
     val nextIndex  = assessmentPage.index + 1
@@ -259,7 +264,7 @@ class CategorisationNavigator @Inject() (categorisationService: CategorisationSe
     val recordId = reasessmentPrep.recordId
 
     answers.get(LongerCategorisationDetailsQuery(recordId)) match {
-      case Some(catInfo) if catInfo.categoryAssessmentsThatNeedAnswers.nonEmpty =>
+      case Some(_) if categorisationService.existsUnansweredCat1Questions(answers, recordId) =>
         val firstAnswer = answers.get(ReassessmentPage(recordId, firstAssessmentIndex))
         if (reassessmentAnswerIsEmpty(firstAnswer) || !firstAnswer.get.isAnswerCopiedFromPreviousAssessment) {
           controllers.categorisation.routes.AssessmentController
@@ -272,9 +277,12 @@ class CategorisationNavigator @Inject() (categorisationService: CategorisationSe
         val scenario = categorisationService.calculateResult(catInfo, answers, recordId)
         if (shouldGoToSupplementaryUnitFromPrepPage(catInfo, scenario)) {
           controllers.categorisation.routes.HasSupplementaryUnitController.onPageLoad(NormalMode, recordId)
-        } else {
-          controllers.categorisation.routes.CategorisationResultController.onPageLoad(recordId, scenario)
-        }
+        } else
+          scenario match {
+            case StandardGoodsNoAssessmentsScenario | Category1NoExemptionsScenario =>
+              controllers.categorisation.routes.CategorisationResultController.onPageLoad(recordId, scenario)
+            case _                                                                  => controllers.categorisation.routes.CyaCategorisationController.onPageLoad(recordId)
+          }
 
       case None => controllers.problem.routes.JourneyRecoveryController.onPageLoad()
 

--- a/app/services/CategorisationService.scala
+++ b/app/services/CategorisationService.scala
@@ -22,6 +22,7 @@ import models._
 import models.ott.CategorisationInfo
 import models.requests.DataRequest
 import pages.categorisation.{AssessmentPage, ReassessmentPage}
+import queries.LongerCategorisationDetailsQuery
 import uk.gov.hmrc.http.HeaderCarrier
 
 import java.time.LocalDate
@@ -34,6 +35,48 @@ class CategorisationService @Inject() (
   profileConnector: TraderProfileConnector
 )(implicit ec: ExecutionContext)
     extends Logging {
+
+  def existsUnansweredCat1Questions(userAnswers: UserAnswers, recordId: String): Boolean =
+    // Determine if there are any unanswered Category 1 questions.
+    userAnswers.get(LongerCategorisationDetailsQuery(recordId)).exists { catInfo =>
+      catInfo.categoryAssessmentsThatNeedAnswers.zipWithIndex.exists { case (assessment, index) =>
+        // Retrieve the answer for this assessment index
+        val maybeAnswer = userAnswers.get(ReassessmentPage(recordId, index))
+
+        // Check if it is Category 1 and either not answered or marked as NotAnsweredYet
+        assessment.isCategory1 && (maybeAnswer.isEmpty || maybeAnswer
+          .exists(_.answer == AssessmentAnswer.NotAnsweredYet))
+      }
+    }
+
+  def reorderRecategorisationAnswers(originalUserAnswers: UserAnswers, recordId: String): Future[UserAnswers] =
+    // Required when recategorising, the user said none to a cat 2 question, and there are no cat 1 assessments to answer.
+    // The order OTT provides them in may be different to the order the user answered them and CYA expects.
+    // ---
+    // Partitions answered and unanswered ReassessmentAnswers into two lists
+    // Uses and reorders both those and their category assessments in LongerCatQuery so that answered questions come first on CYA
+    // Sets the answers in reverse so .set cleanups happen and CYA won't throw unanswered validation errors.
+    // Removes any answers that no longer match the assesments as a fail-safe in case there's a mismatch of codes.
+    for {
+      longerCatQuery             <- Future.fromTry(Try(originalUserAnswers.get(LongerCategorisationDetailsQuery(recordId)).get))
+      assessmentsThatNeedAnswers  = longerCatQuery.categoryAssessmentsThatNeedAnswers
+      answersAndIndexes           = assessmentsThatNeedAnswers.indices.flatMap { index =>
+                                      originalUserAnswers.get(ReassessmentPage(recordId, index)).map(_ -> index)
+                                    }
+      (answered, notAnswered)     = answersAndIndexes.partition(_._1.answer != AssessmentAnswer.NotAnsweredYet)
+      partialReorderedAssessments = (answered ++ notAnswered).map(_._2).map(assessmentsThatNeedAnswers)
+      reorderedAssessments        =
+        partialReorderedAssessments ++ assessmentsThatNeedAnswers.filterNot(partialReorderedAssessments.contains)
+      newLongerCatQuery           = longerCatQuery.copy(categoryAssessmentsThatNeedAnswers = reorderedAssessments)
+      updatedUserAnswers         <-
+        Future.fromTry(originalUserAnswers.set(LongerCategorisationDetailsQuery(recordId), newLongerCatQuery))
+      updatedUserAnswers         <- Future.fromTry(Try {
+                                      (answered ++ notAnswered).zipWithIndex.reverse.foldLeft(updatedUserAnswers) {
+                                        case (answers, (answerWithIndex, newIndex)) =>
+                                          answers.set(ReassessmentPage(recordId, newIndex), answerWithIndex._1).get
+                                      }
+                                    })
+    } yield updatedUserAnswers
 
   def getCategorisationInfo(
     request: DataRequest[_],

--- a/app/services/CategorisationService.scala
+++ b/app/services/CategorisationService.scala
@@ -37,13 +37,10 @@ class CategorisationService @Inject() (
     extends Logging {
 
   def existsUnansweredCat1Questions(userAnswers: UserAnswers, recordId: String): Boolean =
-    // Determine if there are any unanswered Category 1 questions.
     userAnswers.get(LongerCategorisationDetailsQuery(recordId)).exists { catInfo =>
       catInfo.categoryAssessmentsThatNeedAnswers.zipWithIndex.exists { case (assessment, index) =>
-        // Retrieve the answer for this assessment index
         val maybeAnswer = userAnswers.get(ReassessmentPage(recordId, index))
 
-        // Check if it is Category 1 and either not answered or marked as NotAnsweredYet
         assessment.isCategory1 && (maybeAnswer.isEmpty || maybeAnswer
           .exists(_.answer == AssessmentAnswer.NotAnsweredYet))
       }
@@ -56,7 +53,6 @@ class CategorisationService @Inject() (
     // Partitions answered and unanswered ReassessmentAnswers into two lists
     // Uses and reorders both those and their category assessments in LongerCatQuery so that answered questions come first on CYA
     // Sets the answers in reverse so .set cleanups happen and CYA won't throw unanswered validation errors.
-    // Removes any answers that no longer match the assesments as a fail-safe in case there's a mismatch of codes.
     for {
       longerCatQuery             <- Future.fromTry(Try(originalUserAnswers.get(LongerCategorisationDetailsQuery(recordId)).get))
       assessmentsThatNeedAnswers  = longerCatQuery.categoryAssessmentsThatNeedAnswers

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -203,7 +203,7 @@ trait SpecBase
       "measure description"
     )
 
-  lazy val categorisationInfo: CategorisationInfo                         = CategorisationInfo(
+  lazy val categorisationInfo: CategorisationInfo = CategorisationInfo(
     "1234567890",
     "BV",
     Some(validityEndDate),
@@ -212,6 +212,17 @@ trait SpecBase
     Some("Weight, in kilograms"),
     1
   )
+
+  lazy val categorisationInfoWithThreeCat1: CategorisationInfo = CategorisationInfo(
+    "1234567890",
+    "BV",
+    Some(validityEndDate),
+    Seq(category1, category1, category1, category2),
+    Seq(category1, category1, category1, category2),
+    Some("Weight, in kilograms"),
+    1
+  )
+
   val today: Instant                                                      = LocalDate.now().atStartOfDay(ZoneId.of("UTC")).toInstant
   lazy val categorisationInfoWithExpiredCommodityCode: CategorisationInfo = CategorisationInfo(
     "1234567890",

--- a/test/controllers/categorisation/CategorisationPreparationControllerSpec.scala
+++ b/test/controllers/categorisation/CategorisationPreparationControllerSpec.scala
@@ -523,6 +523,8 @@ class CategorisationPreparationControllerSpec extends SpecBase with BeforeAndAft
 
         when(mockCategorisationService.updatingAnswersForRecategorisation(any(), any(), any(), any()))
           .thenReturn(Success(userAnswers))
+        when(mockCategorisationService.reorderRecategorisationAnswers(any(), any()))
+          .thenReturn(Future.successful(userAnswers))
 
         val app = application(userAnswers)
         running(app) {
@@ -601,6 +603,9 @@ class CategorisationPreparationControllerSpec extends SpecBase with BeforeAndAft
 
         when(mockCategorisationService.updatingAnswersForRecategorisation(any(), any(), any(), any()))
           .thenReturn(Success(userAnswers))
+
+        when(mockCategorisationService.reorderRecategorisationAnswers(any(), any()))
+          .thenReturn(Future.successful(userAnswers))
 
         when(mockCategorisationService.calculateResult(any(), any(), any()))
           .thenReturn(StandardGoodsNoAssessmentsScenario)
@@ -703,6 +708,9 @@ class CategorisationPreparationControllerSpec extends SpecBase with BeforeAndAft
         when(mockCategorisationService.updatingAnswersForRecategorisation(any(), any(), any(), any()))
           .thenReturn(Success(userAnswers))
 
+        when(mockCategorisationService.reorderRecategorisationAnswers(any(), any()))
+          .thenReturn(Future.successful(userAnswers))
+
         when(mockCategorisationService.calculateResult(any(), any(), any()))
           .thenReturn(Category2Scenario)
 
@@ -768,6 +776,9 @@ class CategorisationPreparationControllerSpec extends SpecBase with BeforeAndAft
         when(mockCategorisationService.updatingAnswersForRecategorisation(any(), any(), any(), any()))
           .thenReturn(Success(userAnswers))
 
+        when(mockCategorisationService.reorderRecategorisationAnswers(any(), any()))
+          .thenReturn(Future.successful(userAnswers))
+
         val app = application(userAnswers)
         running(app) {
 
@@ -831,6 +842,9 @@ class CategorisationPreparationControllerSpec extends SpecBase with BeforeAndAft
         when(mockCategorisationService.updatingAnswersForRecategorisation(any(), any(), any(), any()))
           .thenReturn(Success(userAnswers))
 
+        when(mockCategorisationService.reorderRecategorisationAnswers(any(), any()))
+          .thenReturn(Future.successful(userAnswers))
+
         val app = application(userAnswers)
         running(app) {
 
@@ -888,6 +902,9 @@ class CategorisationPreparationControllerSpec extends SpecBase with BeforeAndAft
 
         when(mockCategorisationService.updatingAnswersForRecategorisation(any(), any(), any(), any()))
           .thenReturn(Success(userAnswers))
+
+        when(mockCategorisationService.reorderRecategorisationAnswers(any(), any()))
+          .thenReturn(Future.successful(userAnswers))
 
         val app = application(userAnswers)
         running(app) {
@@ -952,6 +969,9 @@ class CategorisationPreparationControllerSpec extends SpecBase with BeforeAndAft
         when(mockCategorisationService.updatingAnswersForRecategorisation(any(), any(), any(), any()))
           .thenReturn(Success(userAnswers))
 
+        when(mockCategorisationService.reorderRecategorisationAnswers(any(), any()))
+          .thenReturn(Future.successful(userAnswers))
+
         val app = application(userAnswers)
         running(app) {
 
@@ -1010,6 +1030,9 @@ class CategorisationPreparationControllerSpec extends SpecBase with BeforeAndAft
             )
             .success
             .value
+
+          when(mockCategorisationService.reorderRecategorisationAnswers(any(), any()))
+            .thenReturn(Future.successful(userAnswers))
 
           val app = application(userAnswers)
           running(app) {

--- a/test/controllers/goodsRecord/SingleRecordControllerSpec.scala
+++ b/test/controllers/goodsRecord/SingleRecordControllerSpec.scala
@@ -19,7 +19,6 @@ package controllers.goodsRecord
 import base.SpecBase
 import base.TestConstants.{testRecordId, userAnswersId}
 import connectors.{GoodsRecordConnector, OttConnector, TraderProfileConnector}
-import controllers.routes
 import models.helper.SupplementaryUnitUpdateJourney
 import models.{Country, NormalMode, UserAnswers}
 import org.mockito.ArgumentCaptor

--- a/test/navigation/categorisation/CategorisationNavigatorCheckModeSpec.scala
+++ b/test/navigation/categorisation/CategorisationNavigatorCheckModeSpec.scala
@@ -36,6 +36,9 @@ class CategorisationNavigatorCheckModeSpec extends SpecBase with BeforeAndAfterE
 
   private val mockCategorisationService = mock[CategorisationService]
 
+  when(mockCategorisationService.existsUnansweredCat1Questions(any(), any())).thenCallRealMethod()
+  when(mockCategorisationService.reorderRecategorisationAnswers(any(), any())).thenCallRealMethod()
+
   private val navigator = new CategorisationNavigator(mockCategorisationService)
 
   "CategorisationNavigator" - {
@@ -608,7 +611,7 @@ class CategorisationNavigatorCheckModeSpec extends SpecBase with BeforeAndAfterE
 
         "third reassessment is unanswered" in {
           val userAnswers = emptyUserAnswers
-            .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
+            .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfoWithThreeCat1)
             .success
             .value
             .set(
@@ -638,7 +641,7 @@ class CategorisationNavigatorCheckModeSpec extends SpecBase with BeforeAndAfterE
 
         "third reassessment is set to NotAnsweredYet" in {
           val userAnswers = emptyUserAnswers
-            .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
+            .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfoWithThreeCat1)
             .success
             .value
             .set(
@@ -675,7 +678,7 @@ class CategorisationNavigatorCheckModeSpec extends SpecBase with BeforeAndAfterE
 
         "because one is answered no" in {
           val userAnswers = emptyUserAnswers
-            .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
+            .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfoWithThreeCat1)
             .success
             .value
             .set(
@@ -700,6 +703,7 @@ class CategorisationNavigatorCheckModeSpec extends SpecBase with BeforeAndAfterE
         }
 
         "because all have already been answered" in {
+
           val userAnswers = emptyUserAnswers
             .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
             .success
@@ -731,6 +735,8 @@ class CategorisationNavigatorCheckModeSpec extends SpecBase with BeforeAndAfterE
             )
             .success
             .value
+
+          when(mockCategorisationService.calculateResult(any(), any(), any())).thenReturn(StandardGoodsScenario)
 
           navigator.nextPage(RecategorisationPreparationPage(testRecordId), CheckMode, userAnswers) mustBe
             controllers.categorisation.routes.CyaCategorisationController.onPageLoad(testRecordId)

--- a/test/navigation/categorisation/CategorisationNavigatorNormalModeSpec.scala
+++ b/test/navigation/categorisation/CategorisationNavigatorNormalModeSpec.scala
@@ -38,6 +38,9 @@ class CategorisationNavigatorNormalModeSpec extends SpecBase with BeforeAndAfter
 
   private val categorisationService = mock[CategorisationService]
 
+  when(categorisationService.existsUnansweredCat1Questions(any(), any())).thenCallRealMethod()
+  when(categorisationService.reorderRecategorisationAnswers(any(), any())).thenCallRealMethod()
+
   private val navigator = new CategorisationNavigator(categorisationService)
 
   private val recordId    = "dummyRecordId"
@@ -811,7 +814,7 @@ class CategorisationNavigatorNormalModeSpec extends SpecBase with BeforeAndAfter
 
         "third reassessment is unanswered" in {
           val userAnswers = emptyUserAnswers
-            .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
+            .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfoWithThreeCat1)
             .success
             .value
             .set(
@@ -841,7 +844,7 @@ class CategorisationNavigatorNormalModeSpec extends SpecBase with BeforeAndAfter
 
         "third reassessment is set to NotAnsweredYet" in {
           val userAnswers = emptyUserAnswers
-            .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
+            .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfoWithThreeCat1)
             .success
             .value
             .set(

--- a/test/services/CategorisationServiceSpec.scala
+++ b/test/services/CategorisationServiceSpec.scala
@@ -106,7 +106,7 @@ class CategorisationServiceSpec extends SpecBase with BeforeAndAfterEach {
     TraderProfile("actorId", "ukims number", None, None, eoriChanged = false)
 
   private val categorisationService =
-    new CategorisationService(mockOttConnector, mockTraderProfileConnector)
+    new CategorisationService(mockOttConnector, mockTraderProfileConnector, mockSessionRepository)
 
   private val mockDataRequest = mock[DataRequest[AnyContent]]
 
@@ -1512,6 +1512,20 @@ class CategorisationServiceSpec extends SpecBase with BeforeAndAfterEach {
 
     "should reorder assessments so that answered ones come first" in {
 
+      // Please note the category3 is actually a category 2 assessment
+      // The name comes from the fact that if you exempt all of them, it results in standard goods category 3
+      // Similarly category2 is actually a category 1 assessment
+
+      val categorisationInfo = CategorisationInfo(
+        "1234567890",
+        "BV",
+        Some(validityEndDate),
+        Seq(category1, category3, category2),
+        Seq(category1, category3, category2),
+        Some("Weight, in kilograms"),
+        1
+      )
+
       val userAnswers = emptyUserAnswers
         .set(LongerCategorisationDetailsQuery(testRecordId), categorisationInfo)
         .success
@@ -1530,8 +1544,8 @@ class CategorisationServiceSpec extends SpecBase with BeforeAndAfterEach {
         "1234567890",
         "BV",
         Some(validityEndDate),
-        Seq(category1, category2, category3),
         Seq(category1, category3, category2),
+        Seq(category1, category2, category3),
         Some("Weight, in kilograms"),
         1
       )


### PR DESCRIPTION
The bug was to ensure that:

When the user says none to a category 2 question in the categorisation journey, they would enter a longer commodity code, begin the _recategorisation_ journey, and not answer any further category 2 questions unless they said exempted the last one they answered none.

Previously, no matter what, at least one extra category 2 question (if it existed), was presented the user when entering the _recategorisation_ journey.

That part is simple enough to fix, the issue was only compounded when visiting the CYA, as it expects answers to be given until the most recent 'none'. When grabbing the assessments from OTT, the order of the users answers, when copied from the original categorisation journey, can get mixed up. This wasn't an issue before as we forced them to answer any required unanswered ones.

Instead of reinventing the wheel, of which I am borderline incapable, I've patched it with methods in the categorisation service. One of which is critical to ensure the categorisation prep accounts for assessment order.

I have two methods on CategorisationService which I use to do that.

`existsUnansweredCat1Questions` returns a bool for if there are cat1 questions that the user needs to provide in the recategorisation journey. Only if this evaluates true when called do I show the user more assessments (since cat 1 would necessitate that they answer them and they will have said 'none' prior to this in categorisation journey to enter the _recategorisation_ journey.

`reorderRecategorisationAnswers` returns user answers where the category assessments and their corresponding answers are reordered such that the answered ones come first. This reordering ensures that the CYA validation doesn't fail.

# Checklist for developers before reviewing
 - [x] I have merged in main
 - [x] I have assigned the PR to me
 - [x] I ran the code with a clean compile test and ensured there are no warnings or deprecations
 - [x] I have run `sbt prePR` to run all tests, format and check the code coverage
 - [x] I have written unit tests to cover any code that I wrote, where necessary
 - [x] I have linked tickets to any TODOs I have written
 - [x] I have run the microservices with the latest SM2 config
 - [x] I have checked all the Acceptance Criteria pass
 - [x] I have run the pipeline journey tests
 - [x] I have run the local journey tests
 - [x] I have spoken to the QAs about any changes that may need to be made to the journey tests OR no changes to the journey tests are necessary
 - [x] I have moved the ticket to Review in Jira
 - [x] I have left a message in tgp-prs on slack to alert other Devs that this ticket is ready for review
 - [x] I have checked my PR is not in draft mode

# Checklist for reviewer 1
- [ ] I have added an emoji to the relevant message in tgp-prs to show I am reviewing
- [ ] I have checked out the branch
- [ ] I have run the microservices with the latest SM2 config
- [ ] I have checked all the Acceptance Criteria pass
- [ ] I reviewed the code and left comments where necessary
- [ ] I have left a message on the relevant tgp-prs message to show that I have finished reviewing

# Checklist for reviewer 2
- [x] I have added an emoji to the relevant message in tgp-prs to show I am reviewing
- [x] I have checked out the branch
- [x] I have run the microservices with the latest SM2 config
- [x] I have checked all the Acceptance Criteria pass
- [ ] I reviewed the code and left comments where necessary
- [ ] I have left a message on the relevant tgp-prs message to show that I have finished reviewing

# Checklist for developers before merging
 - [ ] The PR has been approved by 2 other developers
 - [ ] I have merged in main
 - [ ] I have run `sbt preMerge` to run all tests, check formatting and code coverage
 - [ ] I have run the microservices with the latest SM2 config
 - [ ] I have checked all the Acceptance Criteria pass
 - [ ] I have checked that the QAs have merged in any changes to the journey tests
 - [ ] I have run the pipeline journey tests
 - [ ] I have run the local journey tests

# Reminders for developers after merging
 1. Wait for pipeline to pass
 2. Move ticket to QA column in Jira
 3. Leave message in tgp-qa on slack to alert QAs that this ticket is ready for testing
