### PR TITLE
TGP-2735: Option caused for comprehension on CategoryAssessment.build to fail

### DIFF
--- a/app/models/ott/CategoryAssessment.scala
+++ b/app/models/ott/CategoryAssessment.scala
@@ -52,9 +52,9 @@ object CategoryAssessment {
       theme            <- ottResponse.themes.find(_.id == assessment.themeId)
       exemptions       <- assessment.exemptions.map(x => buildExemption(x.id, x.exemptionType, ottResponse)).sequence
       themeDescription <- ottResponse.themes.find(_.id == assessment.themeId).map(_.theme)
-      regulationUrl    <- ottResponse.legalAct
+      regulationUrl     = ottResponse.legalAct
                             .find(legalAct => legalAct.id.contains(assessment.regulationId))
-                            .map(_.regulationUrl)
+                            .flatMap(_.regulationUrl)
     } yield CategoryAssessment(id, theme.category, exemptions, themeDescription, regulationUrl)
 
   private def buildExemption(id: String, exemptionType: ExemptionType, ottResponse: OttResponse): Option[Exemption] =


### PR DESCRIPTION
The issue is that we wanted the 'concrete' option regulationUrl to pass into the CategoryAssessment constructor, but we were just failing the for if it was None. Changed a `map` to a `flatMap` and a `<-` to a `=`

Unit and UI journey tests pass.